### PR TITLE
Made correction for tof related to tdc and gdc data packets

### DIFF
--- a/sophiread/FastSophiread/src/hit.cpp
+++ b/sophiread/FastSophiread/src/hit.cpp
@@ -66,9 +66,14 @@ Hit::Hit(const char *packet, const unsigned long long tdc, const unsigned long l
   // tof calculation
   // TDC packets not always arrive before corresponding data packets
   if (m_spidertime < TDC_timestamp) {
-    m_tof = m_spidertime - TDC_timestamp + 16666667;  // 1E9 / 60.0 is approximately 16666667
+    m_tof = m_spidertime - TDC_timestamp + 666667;  // 1E9 / 60.0 is approximately 16666667
   } else {
     m_tof = m_spidertime - TDC_timestamp;
+  }
+
+  // some error in SPIDR_timestamp (revisit this fix)
+  if (m_tof*25E-6 > 16.67){
+    m_tof = m_tof - 1073741824;
   }
 
   // pixel address


### PR DESCRIPTION
# Description of Pull Request

## Purpose of work
Previously there are time-of-flight calculations that are incorrectly handled due to `TDC` and `GDC` packets arrival times. 

<!-- If the original issue was raised by a user they should be named here.
NOTE: you can use @GITHUB_USERNAME to reference a user.
-->

## Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
Two main changes:
1. Incorrect constant was used to get previous TDC for a 60 Hz trigger rate. 
2. Added an extra handling for `spidertime` rollover of 2^30. 


## Testing instructions

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

Currently, no testing instructions for this PR, as there are more fixes needed to make to process `TDC` and `GDC`.  

The first approach was to pass `tdc` and `gdc` to `extractHits` function by reference. This approach takes in the loss in hits for pixel packets that arrive before the first `tdc` and `gdc`. This approach works OK with single thread as we're only taking loses in the beginning of the dataset. However, this approach does not work well with multi-threading using `tbb` when the dataset is chunked very finely. We tried chunking the data manually using `tbb` to minimize the losses but the performance becomes closer to single thread speed. 

Chen is implementing another approach by iterating through the dataset first, keep tracking of all `tdc`'s and `gdc`'s to minimize loses for multithreading and hopefully performance hit isn't too huge. 

<!-- and fix #xxxx or close #xxxx xor resolves #xxxx 
NOTE: skip this part if not applicable to your PR.
-->
