### PR TITLE
Optimizing performance for processing raw to events with GDC and TDC

### DIFF
--- a/sophiread/FastSophiread/benchmarks/benchmark_raw2events.cpp
+++ b/sophiread/FastSophiread/benchmarks/benchmark_raw2events.cpp
@@ -129,7 +129,7 @@ void run_single_thread(std::vector<char> raw_data, bool check_tof = false) {
   spdlog::info("Total time: {} s", total_time);
   spdlog::info("Number of hits: {}", n_hits);
   auto speed = n_hits / total_time;
-  spdlog::info("Single thread processing speed: {} hits/s", speed);
+  spdlog::info("Single thread processing speed: {:<e} hits/s", speed);
 
   if (check_tof) {
     check_bad_tof(batches);
@@ -173,7 +173,7 @@ void run_multi_thread(std::vector<char> raw_data, bool check_tof = false) {
   auto elapsed = std::chrono::duration_cast<std::chrono::microseconds>(end - start).count();
   spdlog::info("Multi-thread processing: {} s", elapsed / 1e6);
   auto speed = n_hits / (elapsed / 1e6);
-  spdlog::info("Multi-thread processing speed: {} hits/s", speed);
+  spdlog::info("Multi-thread processing speed: {:<e} hits/s", speed);
 
   if (check_tof) {
     check_bad_tof(batches_mt);

--- a/sophiread/FastSophiread/benchmarks/benchmark_raw2events.cpp
+++ b/sophiread/FastSophiread/benchmarks/benchmark_raw2events.cpp
@@ -26,43 +26,11 @@
 #include <iostream>
 
 #include "abs.h"
+#include "disk_io.h"
 #include "tbb/tbb.h"
 #include "tpx3_fast.h"
 
 using namespace std;
-
-/**
- * @brief Read Timepix3 raw data from file to memory for subsequent analysis.
- *
- * @param filepath
- * @return std::vector<char>
- */
-std::vector<char> readTimepix3RawFile(const std::string& filepath) {
-  // Open the file
-  std::ifstream file(filepath, std::ios::binary | std::ios::ate);
-
-  // Check if file is open successfully
-  if (!file.is_open()) {
-    spdlog::error("Failed to open file: {}", filepath);
-    exit(EXIT_FAILURE);
-  }
-
-  // Get the size of the file
-  std::streamsize fileSize = file.tellg();
-  file.seekg(0, std::ios::beg);
-  spdlog::info("File size (bytes): {}", fileSize);
-
-  // Create a vector to store the data
-  std::vector<char> fileData(fileSize);
-
-  // Read the data
-  file.read(fileData.data(), fileSize);
-
-  // Close the file
-  file.close();
-
-  return fileData;
-}
 
 int main(int argc, char* argv[]) {
   // sanity check
@@ -74,7 +42,7 @@ int main(int argc, char* argv[]) {
   // read raw data
   std::string in_tpx3 = argv[1];
   auto start = std::chrono::high_resolution_clock::now();
-  auto raw_data = readTimepix3RawFile(in_tpx3);
+  auto raw_data = readTPX3RawToCharVec(in_tpx3);
   auto end = std::chrono::high_resolution_clock::now();
   auto elapsed = std::chrono::duration_cast<std::chrono::microseconds>(end - start).count();
   spdlog::info("Read raw data: {} s", elapsed / 1e6);

--- a/sophiread/FastSophiread/include/tpx3_fast.h
+++ b/sophiread/FastSophiread/include/tpx3_fast.h
@@ -43,7 +43,7 @@ struct TPX3 {
       : index(index), num_packets(num_packets), chip_layout_type(chip_layout_type) {
     hits.reserve(num_packets);
     tdcs.reserve(num_packets);
-    gdcs.reserve(num_packets);
+    gdcs.reserve(num_packets);  // assuming 1 gdc per 100 data packets
   };
 
   void emplace_back(const char* packet, const unsigned long long tdc, const unsigned long long gdc) {
@@ -57,12 +57,9 @@ std::vector<TPX3> findTPX3H(const std::vector<char>& raw_bytes);
 std::vector<TPX3> findTPX3H(char* raw_bytes, std::size_t size);
 
 template <typename ForwardIter>
-void extractTGDC(TPX3& tpx3h, ForwardIter bytes_begin, ForwardIter bytes_end, unsigned long& tdc_timestamp,
-                 unsigned long long int& gdc_timestamp);
-void extractTGDC(TPX3& tpx3h, const std::vector<char>& raw_bytes, unsigned long& tdc_timestamp,
-                 unsigned long long int& gdc_timestamp);
-void extractTGDC(TPX3& tpx3h, char* raw_bytes, std::size_t size, unsigned long& tdc_timestamp,
-                 unsigned long long int& gdc_timestamp);
+void findGDC(TPX3& tpx3h, ForwardIter bytes_begin, ForwardIter bytes_end, unsigned long long int& gdc_timestamp);
+void findGDC(TPX3& tpx3h, const std::vector<char>& raw_bytes, unsigned long long int& gdc_timestamp);
+void findGDC(TPX3& tpx3h, char* raw_bytes, std::size_t size, unsigned long long int& gdc_timestamp);
 
 template <typename ForwardIter>
 void extractHits(TPX3& tpx3h, ForwardIter bytes_begin, ForwardIter bytes_end);

--- a/sophiread/FastSophiread/include/tpx3_fast.h
+++ b/sophiread/FastSophiread/include/tpx3_fast.h
@@ -36,7 +36,6 @@ struct TPX3 {
   const int num_packets;       // number of packets in the dataset batch (time packet and data packet)
   const int chip_layout_type;  // data source (sub-chip ID)
   std::vector<Hit> hits;       // hits extracted from the dataset batch
-  std::vector<unsigned long long int> gdcs;  // gdc extracted from the dataset batch
 
   unsigned long tdc_timestamp;       // starting tdc timestamp of the dataset batch
   unsigned long long gdc_timestamp;  // starting gdc timestamp of the dataset batch
@@ -45,7 +44,6 @@ struct TPX3 {
   TPX3(std::size_t index, int num_packets, int chip_layout_type)
       : index(index), num_packets(num_packets), chip_layout_type(chip_layout_type) {
     hits.reserve(num_packets);  // assuming 1 hit per data packet
-    gdcs.reserve(num_packets);  // assuming 1 gdc per 100 data packets
   };
 
   void emplace_back(const char* packet, const unsigned long long tdc, const unsigned long long gdc) {

--- a/sophiread/FastSophiread/include/tpx3_fast.h
+++ b/sophiread/FastSophiread/include/tpx3_fast.h
@@ -76,3 +76,7 @@ void update_tdc_timestamp(const char* char_array, const unsigned long long& gdc_
 
 void update_gdc_timestamp_and_timer_lsb32(const char* char_array, unsigned long& timer_lsb32,
                                           unsigned long long& gdc_timestamp);
+
+template <typename ForwardIter>
+void process_tpx3_packets(TPX3& tpx3h, ForwardIter bytes_begin, ForwardIter bytes_end, unsigned long& tdc_timestamp,
+                          unsigned long long int& gdc_timestamp, unsigned long& timer_lsb32, bool extract_hits = true);

--- a/sophiread/FastSophiread/include/tpx3_fast.h
+++ b/sophiread/FastSophiread/include/tpx3_fast.h
@@ -36,13 +36,15 @@ struct TPX3 {
   const int num_packets;       // number of packets in the dataset batch (time packet and data packet)
   const int chip_layout_type;  // data source (sub-chip ID)
   std::vector<Hit> hits;       // hits extracted from the dataset batch
-  std::vector<unsigned long> tdcs;           // tdc extracted from the dataset batch
   std::vector<unsigned long long int> gdcs;  // gdc extracted from the dataset batch
+
+  unsigned long tdc_timestamp;       // starting tdc timestamp of the dataset batch
+  unsigned long long gdc_timestamp;  // starting gdc timestamp of the dataset batch
+  unsigned long timer_lsb32;         // starting Timer_LSB32 of the dataset batch
 
   TPX3(std::size_t index, int num_packets, int chip_layout_type)
       : index(index), num_packets(num_packets), chip_layout_type(chip_layout_type) {
-    hits.reserve(num_packets);
-    tdcs.reserve(num_packets);
+    hits.reserve(num_packets);  // assuming 1 hit per data packet
     gdcs.reserve(num_packets);  // assuming 1 gdc per 100 data packets
   };
 
@@ -57,9 +59,12 @@ std::vector<TPX3> findTPX3H(const std::vector<char>& raw_bytes);
 std::vector<TPX3> findTPX3H(char* raw_bytes, std::size_t size);
 
 template <typename ForwardIter>
-void findGDC(TPX3& tpx3h, ForwardIter bytes_begin, ForwardIter bytes_end, unsigned long long int& gdc_timestamp);
-void findGDC(TPX3& tpx3h, const std::vector<char>& raw_bytes, unsigned long long int& gdc_timestamp);
-void findGDC(TPX3& tpx3h, char* raw_bytes, std::size_t size, unsigned long long int& gdc_timestamp);
+void updateTimestamp(TPX3& tpx3h, ForwardIter bytes_begin, ForwardIter bytes_end, unsigned long& tdc_timestamp,
+                     unsigned long long int& gdc_timestamp, unsigned long& timer_lsb32);
+void updateTimestamp(TPX3& tpx3h, const std::vector<char>& raw_bytes, unsigned long& tdc_timestamp,
+                     unsigned long long int& gdc_timestamp, unsigned long& timer_lsb32);
+void updateTimestamp(TPX3& tpx3h, char* raw_bytes, std::size_t size, unsigned long& tdc_timestamp,
+                     unsigned long long int& gdc_timestamp, unsigned long& timer_lsb32);
 
 template <typename ForwardIter>
 void extractHits(TPX3& tpx3h, ForwardIter bytes_begin, ForwardIter bytes_end);

--- a/sophiread/FastSophiread/include/tpx3_fast.h
+++ b/sophiread/FastSophiread/include/tpx3_fast.h
@@ -70,3 +70,9 @@ template <typename ForwardIter>
 void extractHits(TPX3& tpx3h, ForwardIter bytes_begin, ForwardIter bytes_end);
 void extractHits(TPX3& tpx3h, const std::vector<char>& raw_bytes);
 void extractHits(TPX3& tpx3h, char* raw_bytes, std::size_t size);
+
+void update_tdc_timestamp(const char* char_array, const unsigned long long& gdc_timestamp,
+                          unsigned long& tdc_timestamp);
+
+void update_gdc_timestamp_and_timer_lsb32(const char* char_array, unsigned long& timer_lsb32,
+                                          unsigned long long& gdc_timestamp);

--- a/sophiread/FastSophiread/src/abs.cpp
+++ b/sophiread/FastSophiread/src/abs.cpp
@@ -30,7 +30,7 @@
 /**
  * @brief Generate cluster labels for the hits.
  *
- * @param data: a vector of hits.
+ * @param[in] data: a vector of hits.
  */
 void ABS::fit(const std::vector<Hit>& data) {
   // reserve space for the cluster labels and initialize to -1
@@ -128,7 +128,7 @@ void ABS::fit(const std::vector<Hit>& data) {
 /**
  * @brief Predict the clusters by retrieving the labels of the hits.
  *
- * @param data: a vector of hits.
+ * @param[in] data: a vector of hits.
  * @return std::vector<NeutronEvent>: a vector of neutron events.
  */
 std::vector<Neutron> ABS::get_events(const std::vector<Hit>& data) {

--- a/sophiread/FastSophiread/src/centroid.cpp
+++ b/sophiread/FastSophiread/src/centroid.cpp
@@ -25,7 +25,7 @@
 /**
  * @brief Perform centroid fitting on the hits.
  *
- * @param data: a vector of hits.
+ * @param[in] data: a vector of hits.
  * @return NeutronEvent: a neutron event.
  */
 Neutron Centroid::fit(const std::vector<Hit>& data) {

--- a/sophiread/FastSophiread/src/disk_io.cpp
+++ b/sophiread/FastSophiread/src/disk_io.cpp
@@ -26,7 +26,7 @@
 /**
  * @brief Read Timepix3 raw data from file into memory as a vector of char for subsequent analysis.
  *
- * @param tpx3file
+ * @param[in] tpx3file
  * @return std::vector<char>
  */
 std::vector<char> readTPX3RawToCharVec(const std::string& tpx3file) {

--- a/sophiread/FastSophiread/src/fastgaussian.cpp
+++ b/sophiread/FastSophiread/src/fastgaussian.cpp
@@ -32,7 +32,7 @@
 /**
  * @brief Get the Median of a vector of doubles.
  *
- * @param data: a vector of doubles.
+ * @param[in] data: a vector of doubles.
  * @return double
  */
 double getMedian(const std::vector<double>& data) {
@@ -48,7 +48,7 @@ double getMedian(const std::vector<double>& data) {
 /**
  * @brief Perform gaussian fitting on the hits.
  *
- * @param data: a vector of hits.
+ * @param[in] data: a vector of hits.
  * @return NeutronEvent
  */
 Neutron FastGaussian::fit(const std::vector<Hit>& data) {

--- a/sophiread/FastSophiread/src/hit.cpp
+++ b/sophiread/FastSophiread/src/hit.cpp
@@ -25,10 +25,10 @@
 /**
  * @brief Special constructor that construct a Hit from raw bytes.
  *
- * @param packet
- * @param tdc
- * @param gdc
- * @param chip_layout_type
+ * @param[in] packet
+ * @param[in] tdc
+ * @param[in] gdc
+ * @param[in] chip_layout_type
  */
 Hit::Hit(const char *packet, const unsigned long long TDC_timestamp, const unsigned long long GDC_timestamp,
          const int chip_layout_type) {

--- a/sophiread/FastSophiread/src/tpx3_fast.cpp
+++ b/sophiread/FastSophiread/src/tpx3_fast.cpp
@@ -143,14 +143,8 @@ void updateTimestamp(TPX3 &tpx3h, char *raw_bytes, std::size_t size, unsigned lo
  */
 template <typename ForwardIter>
 void extractHits(TPX3 &tpx3h, ForwardIter bytes_begin, ForwardIter bytes_end) {
-  // Define the local variables
-  // -- TDC
-  unsigned long tdc_timestamp = tpx3h.tdc_timestamp;
-  // -- GDC
-  unsigned long Timer_LSB32 = tpx3h.timer_lsb32;
-  unsigned long long gdc_timestamp = tpx3h.gdc_timestamp;
-
-  process_tpx3_packets(tpx3h, bytes_begin, bytes_end, tdc_timestamp, gdc_timestamp, Timer_LSB32, true);
+  process_tpx3_packets(tpx3h, bytes_begin, bytes_end, tpx3h.tdc_timestamp, tpx3h.gdc_timestamp, tpx3h.timer_lsb32,
+                       true);
 }
 
 /**

--- a/sophiread/FastSophiread/tests/test_tpx3.cpp
+++ b/sophiread/FastSophiread/tests/test_tpx3.cpp
@@ -88,9 +88,11 @@ TEST(TPX3FuncTest, TestExtractHits) {
   auto batches = findTPX3H(rawdata);
 
   // locate gdc and tdc
+  unsigned long tdc_timestamp = 0;
   unsigned long long int gdc_timestamp = 0;
+  unsigned long timer_lsb32 = 0;
   for (auto& tpx3 : batches) {
-    findGDC(tpx3, rawdata, gdc_timestamp);
+    updateTimestamp(tpx3, rawdata, tdc_timestamp, gdc_timestamp, timer_lsb32);
   }
 
   // extract hits

--- a/sophiread/FastSophiread/tests/test_tpx3.cpp
+++ b/sophiread/FastSophiread/tests/test_tpx3.cpp
@@ -88,10 +88,9 @@ TEST(TPX3FuncTest, TestExtractHits) {
   auto batches = findTPX3H(rawdata);
 
   // locate gdc and tdc
-  unsigned long tdc_timestamp = 0;
   unsigned long long int gdc_timestamp = 0;
   for (auto& tpx3 : batches) {
-    extractTGDC(tpx3, rawdata, tdc_timestamp, gdc_timestamp);
+    findGDC(tpx3, rawdata, gdc_timestamp);
   }
 
   // extract hits


### PR DESCRIPTION
# Description of Pull Request

This pull request optimize the overall performance of processing raw data (with TDC and GDC turned on) to neutron events.

Example results:
```bash
8cz in 🌐 cg1d-daq1 in mcpevent2hist/sophiread/build on  opt_raw2event_with_tgdc via △ v3.27.4 via 🅒 sophiread on ☁️   
❯ ./FastSophireadBenchmarks_raw2events.app ~/tmp/suann_socket_uvlight_5s_serval32.tpx3 
[2023-09-16 22:41:32.653] [info] File size: 4788526376 bytes
[2023-09-16 22:42:15.128] [info] Read raw data: 42.477315 s
[2023-09-16 22:42:15.535] [info] Single thread processing...
[2023-09-16 22:42:16.289] [info] Locate all headers: 0.754348 s
[2023-09-16 22:42:16.609] [info] Locate all gdc timestamps: 0.320256 s
[2023-09-16 22:43:02.250] [info] Get all hits: 45.640978999999994 s
[2023-09-16 22:43:03.720] [info] Total time: 46.715582999999995 s
[2023-09-16 22:43:03.720] [info] Number of hits: 596759877
[2023-09-16 22:43:03.720] [info] Single thread processing speed: 1.277432e+07 hits/s
[2023-09-16 22:43:16.070] [info] bad/total hits: 0/596759877
[2023-09-16 22:43:17.756] [info] Multi-thread processing...
[2023-09-16 22:43:25.640] [info] Number of hits: 596759877
[2023-09-16 22:43:25.640] [info] Multi-thread processing: 6.425933 s
[2023-09-16 22:43:25.640] [info] Multi-thread processing speed: 9.286743e+07 hits/s
[2023-09-16 22:43:37.983] [info] bad/total hits: 0/596759877

8cz in 🌐 cg1d-daq1 in mcpevent2hist/sophiread/build on  opt_raw2event_with_tgdc via △ v3.27.4 via 🅒 sophiread on ☁️   took 2m6s 
❯ ./FastSophireadBenchmarks_raw2events.app ~/tmp/suann_socket_uvlight_5s_serval32.tpx3 
[2023-09-16 22:43:44.941] [info] File size: 4788526376 bytes
[2023-09-16 22:43:45.656] [info] Read raw data: 0.7171339999999999 s
[2023-09-16 22:43:46.055] [info] Single thread processing...
[2023-09-16 22:43:46.816] [info] Locate all headers: 0.760506 s
[2023-09-16 22:43:47.134] [info] Locate all gdc timestamps: 0.318445 s
[2023-09-16 22:44:32.744] [info] Get all hits: 45.610209999999995 s
[2023-09-16 22:44:34.176] [info] Total time: 46.689161 s
[2023-09-16 22:44:34.176] [info] Number of hits: 596759877
[2023-09-16 22:44:34.176] [info] Single thread processing speed: 1.278155e+07 hits/s
[2023-09-16 22:44:46.593] [info] bad/total hits: 0/596759877
[2023-09-16 22:44:48.285] [info] Multi-thread processing...
[2023-09-16 22:44:56.275] [info] Number of hits: 596759877
[2023-09-16 22:44:56.275] [info] Multi-thread processing: 6.532737999999999 s
[2023-09-16 22:44:56.275] [info] Multi-thread processing speed: 9.134912e+07 hits/s
[2023-09-16 22:45:08.911] [info] bad/total hits: 0/596759877
```


## Purpose of work
<!--
Why has this work been done?
If there is no linked issue please provide appropriate context for this work.
-->

With added time stamp (TDC and GDC), additional time stamp sync is needed among TPX3 instances in order for multi-threading to generate correct results.
An additional low overhead step is added to scan the key/starting time stamps for each TPX3 so that subsequent processing can have correct TOF results.

<!-- If the original issue was raised by a user they should be named here.
NOTE: you can use @GITHUB_USERNAME to reference a user.
-->

## Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
1. Add new low overhead function to scan key/starting timestamp for each TPX3 header.
2. Update unit test and switch testing data to dataset with proper timestamp.
3. Update API calls in benchmark apps to use the new syntax.
4. Remove dead code.
5. Refactor the source code to reduce code duplications.
6. Update doc string for functions in `tpx3_fast.cpp` to indicate data flow direction.

## Additional detail of work
<!-- [Optional] If there is additional detail that is relevant to this PR, please provide it here.
-->

N/A

## Testing instructions

- Build the branch.
- Run all unit test with `ctest -V --output-on-failure`.
- Run benchmark app with dataset that has GDC and TDC turned.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- and fix #xxxx or close #xxxx xor resolves #xxxx 
NOTE: skip this part if not applicable to your PR.
-->
