### PR TITLE
Issue/16

### DIFF
--- a/sophiread/CMakeLists.txt
+++ b/sophiread/CMakeLists.txt
@@ -12,7 +12,7 @@ set(CMAKE_CXX_STANDARD 14)
 
 # Dependencies
 find_package(Eigen3 REQUIRED)
-# find_package(OpenMP REQUIRED)
+find_package(OpenMP REQUIRED)
 find_package(spdlog REQUIRED)
 find_package(HDF5 REQUIRED)
 find_package(GTest REQUIRED)
@@ -31,17 +31,17 @@ file(COPY ${CMAKE_SOURCE_DIR}/resources/data DESTINATION ${CMAKE_BINARY_DIR})
 add_compile_options(
   -O3
   -std=c++20
-  -march=native
+#  -march=native
   -ffast-math
   -pthread
   -Wall
   -Wextra
-  # ${OpenMP_CXX_FLAGS}
+  ${OpenMP_CXX_FLAGS}
 )
 
 # Add Sophiread library
 # NOTE: this will take care of the testing as well
-# add_subdirectory(SophireadLib)
+add_subdirectory(SophireadLib)
 
 # Add FastSophiread library
 add_subdirectory(FastSophiread)
@@ -50,7 +50,7 @@ add_subdirectory(FastSophiread)
 # add_subdirectory(SophireadCLI)
 
 # Add Sophiread stream command line interface
-# add_subdirectory(SophireadStreamCLI)
+add_subdirectory(SophireadStreamCLI)
 
 # Add Sophiread GUI application
 # add_subdirectory(SophireadGUI)

--- a/sophiread/CMakeLists.txt
+++ b/sophiread/CMakeLists.txt
@@ -12,7 +12,7 @@ set(CMAKE_CXX_STANDARD 14)
 
 # Dependencies
 find_package(Eigen3 REQUIRED)
-find_package(OpenMP REQUIRED)
+# find_package(OpenMP REQUIRED)
 find_package(spdlog REQUIRED)
 find_package(HDF5 REQUIRED)
 find_package(GTest REQUIRED)
@@ -36,12 +36,12 @@ add_compile_options(
   -pthread
   -Wall
   -Wextra
-  ${OpenMP_CXX_FLAGS}
+  # ${OpenMP_CXX_FLAGS}
 )
 
 # Add Sophiread library
 # NOTE: this will take care of the testing as well
-add_subdirectory(SophireadLib)
+# add_subdirectory(SophireadLib)
 
 # Add FastSophiread library
 add_subdirectory(FastSophiread)
@@ -50,7 +50,7 @@ add_subdirectory(FastSophiread)
 # add_subdirectory(SophireadCLI)
 
 # Add Sophiread stream command line interface
-add_subdirectory(SophireadStreamCLI)
+# add_subdirectory(SophireadStreamCLI)
 
 # Add Sophiread GUI application
 # add_subdirectory(SophireadGUI)

--- a/sophiread/environment_mac.yml
+++ b/sophiread/environment_mac.yml
@@ -13,6 +13,10 @@ dependencies:
   - eigen
   - tbb-devel
   - spdlog
+  #- mlpack
+  - cereal
+  - armadillo
+  - ensmallen
 
   # Not Windows, OpenGL implementation:
   # - mesalib>=18.0.0

--- a/sophiread/environment_mac.yml
+++ b/sophiread/environment_mac.yml
@@ -13,10 +13,6 @@ dependencies:
   - eigen
   - tbb-devel
   - spdlog
-  #- mlpack
-  - cereal
-  - armadillo
-  - ensmallen
 
   # Not Windows, OpenGL implementation:
   # - mesalib>=18.0.0

--- a/sophiread/resources/vendor/mlpack.org/README.md
+++ b/sophiread/resources/vendor/mlpack.org/README.md
@@ -1,0 +1,21 @@
+# mlpack for macos
+
+https://www.mlpack.org/getstarted.html
+
+Using conda to get to mlpack only works for Linux installs.  For Mac, we must use source.
+
+https://stackoverflow.com/questions/6241922/how-to-properly-set-cmake-install-prefix-from-the-command-line
+
+So use `cmake -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} ..`
+
+## Recipe
+
+```
+conda activate sophiread
+wget -c http://mlpack.org/files/mlpack-4.2.1.tar.gz -O - | tar -xz
+mkdir mlpack-4.2.1/build
+cd mlpack-4.2.1/build
+cmake -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} ..
+make -j8
+make install
+```


### PR DESCRIPTION
# Description of Pull Request

Recipe and method for building mlpack without requiring the [modifications described](https://github.com/ornlneutronimaging/mcpevent2hist/issues/16#issuecomment-1610007024).

## Purpose of work

Build on M1 Mac

## Summary of work

Update `environment_mac.yml` to contain needed dependencies for building mlpack from source.
Add instructions and recipe for building mlpack into the `sophiread` conda environment.

## Additional detail of work

Instructions at https://www.mlpack.org/getstarted.html indicate that `mlpack` is not available in conda environments for macOS like it is for Linux.  The build-from-source instructions from C++ describe using `brew`, but this leads to the issues described in #16.  Here is a method to use the `sophiread` conda environment already in use to build `mlpack` with (presumably) full OpenMP support offered on M1+later silicon targeted by the Apple clang compiler.

The trick is to build `mlpack` using `cmake -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} ..` which builds from source, *using* the conda environment, and configuring mlpack's `make install` to install *into* that same conda environment.

## Testing instructions

1. Create the `sophiread` conda environment for macOS using `environment_mac.yml` as prescribed
2. Activate the `sophiread` environment
3. Follow the recipe in `./sophiread/resources/vendor/mlpack.org/README.md` to build/install `mlpack`
4. Build `sophiread` as prescribed
5. Verify all functions work correctly

## Appendix

Some additional detail of the resulting environment and test output:

```
1c1
< # packages in environment at /Users/6ov/anaconda3/envs/sophiread.issue.16:
---
> # packages in environment at /Users/6ov/anaconda3/envs/sophiread.issue.16.1:
3a4,5
> armadillo                 12.6.4               h436c9e7_0    conda-forge
> arpack                    3.7.0                h58ebc17_2    conda-forge
8a11
> cereal                    1.3.2                hd8ed1ab_0    conda-forge
13a17
> ensmallen                 2.19.1               h1ad6298_0    conda-forge
38a43,44
> libblas                   3.9.0           18_osxarm64_openblas    conda-forge
> libcblas                  3.9.0           18_osxarm64_openblas    conda-forge
52a59
> liblapack                 3.9.0           18_osxarm64_openblas    conda-forge
54a62
> libopenblas               0.3.24          openmp_hd76b1f2_0    conda-forge
73a82
> superlu                   5.2.2                hc615359_0    conda-forge


(sophiread.issue.16.1) MAC132540:build$ make test
Running tests...
Test project /Users/xxx/Desktop/Projects/github/mcpevent2hist/sophiread/build
      Start  1: FileHandlingTest.ReadTPX3RawData
 1/27 Test  #1: FileHandlingTest.ReadTPX3RawData ..........   Passed    0.68 sec
      Start  2: FileHandlingTest.VerifyTiming
 2/27 Test  #2: FileHandlingTest.VerifyTiming .............   Passed    0.01 sec
      Start  3: FileHandlingTest.VerifyRollover
 3/27 Test  #3: FileHandlingTest.VerifyRollover ...........   Passed    0.01 sec
      Start  4: FileHandlingTest.ParseUserDefinedParams
 4/27 Test  #4: FileHandlingTest.ParseUserDefinedParams ...   Passed    0.01 sec
      Start  5: Clustering.ABSAlgorithm
 5/27 Test  #5: Clustering.ABSAlgorithm ...................   Passed    0.01 sec
      Start  6: Clustering.DBSCANAlgorithm
 6/27 Test  #6: Clustering.DBSCANAlgorithm ................   Passed    0.01 sec
      Start  7: PeakFitting.CentroidAlgorithm
 7/27 Test  #7: PeakFitting.CentroidAlgorithm .............   Passed    0.01 sec
      Start  8: PeakFitting.FastGaussianAlgorithm
 8/27 Test  #8: PeakFitting.FastGaussianAlgorithm .........   Passed    0.01 sec
      Start  9: DiskIOTest.ReadTPX3RawToCharVec
 9/27 Test  #9: DiskIOTest.ReadTPX3RawToCharVec ...........   Passed    0.04 sec
      Start 10: HitTest.CheckSpidertime
10/27 Test #10: HitTest.CheckSpidertime ...................   Passed    0.01 sec
      Start 11: HitTest.CheckSpidertimens
11/27 Test #11: HitTest.CheckSpidertimens .................   Passed    0.01 sec
      Start 12: HitTest.CheckTOF
12/27 Test #12: HitTest.CheckTOF ..........................   Passed    0.01 sec
      Start 13: HitTest.CheckTOFns
13/27 Test #13: HitTest.CheckTOFns ........................   Passed    0.01 sec
      Start 14: HitTest.CheckXCoordinate
14/27 Test #14: HitTest.CheckXCoordinate ..................   Passed    0.00 sec
      Start 15: HitTest.CheckYCoordinate
15/27 Test #15: HitTest.CheckYCoordinate ..................   Passed    0.01 sec
      Start 16: TPX3Test.CheckIndex
16/27 Test #16: TPX3Test.CheckIndex .......................   Passed    0.01 sec
      Start 17: TPX3Test.CheckNumPackets
17/27 Test #17: TPX3Test.CheckNumPackets ..................   Passed    0.00 sec
      Start 18: TPX3Test.CheckChipLayoutType
18/27 Test #18: TPX3Test.CheckChipLayoutType ..............   Passed    0.01 sec
      Start 19: TPX3Test.CheckHitsSize
19/27 Test #19: TPX3Test.CheckHitsSize ....................   Passed    0.01 sec
      Start 20: TPX3FuncTest.TestFindTPX3H
20/27 Test #20: TPX3FuncTest.TestFindTPX3H ................   Passed    0.02 sec
      Start 21: TPX3FuncTest.TestExtractHits
21/27 Test #21: TPX3FuncTest.TestExtractHits ..............   Passed    0.02 sec
      Start 22: ABSTest.ConstructorAndMethods
22/27 Test #22: ABSTest.ConstructorAndMethods .............   Passed    0.01 sec
      Start 23: ABSTest.FitNeutronEvents
23/27 Test #23: ABSTest.FitNeutronEvents ..................   Passed    0.01 sec
      Start 24: CentroidTest.CentroidWeighted
24/27 Test #24: CentroidTest.CentroidWeighted .............   Passed    0.01 sec
      Start 25: CentroidTest.CentroidWeightedWithScale
25/27 Test #25: CentroidTest.CentroidWeightedWithScale ....   Passed    0.01 sec
      Start 26: CentroidTest.CentroidUnweighted
26/27 Test #26: CentroidTest.CentroidUnweighted ...........   Passed    0.01 sec
      Start 27: FastGaussianTest.FastGaussianWeighted
27/27 Test #27: FastGaussianTest.FastGaussianWeighted .....   Passed    0.00 sec

100% tests passed, 0 tests failed out of 27

Total Test time (real) =   0.94 sec

(sophiread.issue.16.1) MAC132540:build$ ./FastSophireadBenchmarks_raw2events.app data/suann_socket_background_serval32.tpx3 
[2023-09-17 08:13:11.928] [info] File size (bytes): 2363680
[2023-09-17 08:13:11.929] [info] Read raw data: 0.001488 s
[2023-09-17 08:13:11.929] [info] Single thread processing...
[2023-09-17 08:13:11.979] [info] Number of hits: 98533
[2023-09-17 08:13:11.979] [info] Number of events: 89365
[2023-09-17 08:13:11.979] [info] Single thread processing: 0.046941 s
[2023-09-17 08:13:11.979] [info] Single thread processing speed: 2099081.8261221536 hits/s
[2023-09-17 08:13:11.979] [info] Multi-thread processing...
[2023-09-17 08:13:12.008] [info] Number of hits: 98533
[2023-09-17 08:13:12.008] [info] Multi-thread processing: 0.026562 s
[2023-09-17 08:13:12.008] [info] Multi-thread processing speed: 3709547.473834802 hits/s
[2023-09-17 08:13:12.009] [info] bad/total hits: 0/98533
```
