### PR TITLE
Add HDF IO support and connect SophireadCLI with FastSophiread

### DIFF
--- a/sophiread/CMakeLists.txt
+++ b/sophiread/CMakeLists.txt
@@ -14,9 +14,11 @@ set(CMAKE_CXX_STANDARD 14)
 find_package(Eigen3 REQUIRED)
 # find_package(OpenMP REQUIRED)
 find_package(spdlog REQUIRED)
-find_package(HDF5 REQUIRED)
+find_package(HDF5 REQUIRED COMPONENTS CXX)
 find_package(GTest REQUIRED)
 # find_package(Qt5 COMPONENTS Widgets REQUIRED)
+
+include_directories(${HDF5_INCLUDE_DIRS})
 
 link_directories(
     $ENV{CONDA_PREFIX}/lib

--- a/sophiread/CMakeLists.txt
+++ b/sophiread/CMakeLists.txt
@@ -47,7 +47,7 @@ add_compile_options(
 add_subdirectory(FastSophiread)
 
 # Add Sophiread command line interface
-# add_subdirectory(SophireadCLI)
+add_subdirectory(SophireadCLI)
 
 # Add Sophiread stream command line interface
 # add_subdirectory(SophireadStreamCLI)

--- a/sophiread/CMakeLists.txt
+++ b/sophiread/CMakeLists.txt
@@ -7,12 +7,11 @@ execute_process(COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/scripts/version.sh -s print
 project("Sophiread" VERSION ${SOPHIREAD_VERSION})
 
 # set(CMAKE_BUILD_TYPE DEBUG)
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 20)
 # set(CMAKE_AUTOMOC ON)  # for meta object compiler, needed for Qt5
 
 # Dependencies
 find_package(Eigen3 REQUIRED)
-# find_package(OpenMP REQUIRED)
 find_package(spdlog REQUIRED)
 find_package(HDF5 REQUIRED COMPONENTS CXX)
 find_package(GTest REQUIRED)
@@ -38,7 +37,6 @@ add_compile_options(
   -pthread
   -Wall
   -Wextra
-  # ${OpenMP_CXX_FLAGS}
 )
 
 # Add Sophiread library

--- a/sophiread/FastSophiread/CMakeLists.txt
+++ b/sophiread/FastSophiread/CMakeLists.txt
@@ -20,10 +20,7 @@ set(SRC_FAST_FILES
 )
 
 # ------------- SophireadLibFast -------------- #
-add_library(
-    FastSophiread
-    ${SRC_FAST_FILES}
-)
+add_library(FastSophiread ${SRC_FAST_FILES})
 
 # ----------------- TESTS ----------------- #
 # DiskIO Tests
@@ -34,11 +31,11 @@ add_executable(
 target_link_libraries(
     SophireadTests_diskio
     FastSophiread
-    pthread
     tbb
     spdlog::spdlog
     GTest::GTest
     GTest::Main
+    ${HDF5_LIBRARIES}
 )
 gtest_discover_tests(SophireadTests_diskio)
 # Hit Test
@@ -69,6 +66,7 @@ target_link_libraries(
     spdlog::spdlog
     GTest::GTest
     GTest::Main
+    ${HDF5_LIBRARIES}
 )
 gtest_discover_tests(SophireadTests_tpx3)
 # ABS Test
@@ -129,6 +127,7 @@ target_link_libraries(
     pthread
     tbb
     spdlog::spdlog
+    ${HDF5_LIBRARIES}
 )
 add_custom_command(TARGET SophireadBenchmarks_raw2hits POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E create_symlink 
@@ -163,6 +162,7 @@ target_link_libraries(
     pthread
     tbb
     spdlog::spdlog
+    ${HDF5_LIBRARIES}
 )
 add_custom_command(TARGET SophireadBenchmarks_raw2events POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E create_symlink 

--- a/sophiread/FastSophiread/benchmarks/benchmark_raw2events.cpp
+++ b/sophiread/FastSophiread/benchmarks/benchmark_raw2events.cpp
@@ -20,6 +20,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include <spdlog/spdlog.h>
+#include <tbb/tbb.h>
 
 #include <chrono>
 #include <fstream>
@@ -27,7 +28,6 @@
 
 #include "abs.h"
 #include "disk_io.h"
-#include "tbb/tbb.h"
 #include "tpx3_fast.h"
 
 /**

--- a/sophiread/FastSophiread/include/disk_io.h
+++ b/sophiread/FastSophiread/include/disk_io.h
@@ -24,6 +24,7 @@
 #include <H5Cpp.h>
 
 #include <fstream>
+#include <functional>
 #include <iostream>
 #include <vector>
 

--- a/sophiread/FastSophiread/include/disk_io.h
+++ b/sophiread/FastSophiread/include/disk_io.h
@@ -40,13 +40,18 @@ void writeDatasetToGroup(H5::Group& group, const std::string& dataset_name, Forw
 
 std::string generateGroupName(H5::H5File& file, const std::string& baseName);
 
+template <typename T, typename ForwardIterator>
+void saveOrAppendToHDF5(
+    const std::string& out_file_name, ForwardIterator data_begin, ForwardIterator data_end,
+    const std::string& baseGroupName,
+    const std::vector<std::pair<std::string, std::function<T(const decltype(*data_begin)&)>>>& attributes, bool append);
+
 template <typename ForwardIterator>
 void saveOrAppendHitsToHDF5(const std::string& out_file_name, ForwardIterator hits_begin, ForwardIterator hits_end,
                             bool appendMode = false);
 template <typename ForwardIterator>
 void saveHitsToHDF5(const std::string& out_file_path, ForwardIterator hits_begin, ForwardIterator hits_end);
 void saveHitsToHDF5(const std::string& out_file_path, const std::vector<Hit>& hits);
-
 template <typename ForwardIterator>
 void appendHitsToHDF5(const std::string& out_file_name, ForwardIterator hits_begin, ForwardIterator hits_end);
 void appendHitsToHDF5(const std::string& out_file_name, const std::vector<Hit>& hits);
@@ -57,7 +62,6 @@ void saveOrAppendNeutronToHDF5(const std::string& out_file_name, ForwardIterator
 template <typename ForwardIterator>
 void saveNeutronToHDF5(const std::string& out_file_name, ForwardIterator neutron_begin, ForwardIterator neutron_end);
 void saveNeutronToHDF5(const std::string& out_file_name, const std::vector<Neutron>& neutrons);
-
 template <typename ForwardIterator>
 void appendNeutronToHDF5(const std::string& out_file_name, ForwardIterator neutron_begin, ForwardIterator neutron_end);
 void appendNeutronToHDF5(const std::string& out_file_name, const std::vector<Neutron>& neutrons);

--- a/sophiread/FastSophiread/include/disk_io.h
+++ b/sophiread/FastSophiread/include/disk_io.h
@@ -36,7 +36,7 @@ std::string generateFileNameWithMicroTimestamp(const std::string& originalFileNa
 
 template <typename ForwardIterator>
 void saveHitsToHDF5(const std::string& out_file_path, ForwardIterator hits_begin, ForwardIterator hits_end);
+
 void saveHitsToHDF5(const std::string& out_file_path, const std::vector<Hit>& hits);
-void saveHitsToHDF5(const std::string& out_file_path, const Hit* hits, const size_t num_hits);
 
 void saveNeutronToHDF5(const std::string out_file_path, const std::vector<Neutron>& neutrons);

--- a/sophiread/FastSophiread/include/disk_io.h
+++ b/sophiread/FastSophiread/include/disk_io.h
@@ -21,8 +21,22 @@
  */
 #pragma once
 
+#include <H5Cpp.h>
+
 #include <fstream>
 #include <iostream>
 #include <vector>
 
+#include "hit.h"
+#include "neutron.h"
+
 std::vector<char> readTPX3RawToCharVec(const std::string& tpx3file);
+
+std::string generateFileNameWithMicroTimestamp(const std::string& originalFileName);
+
+template <typename ForwardIterator>
+void saveHitsToHDF5(const std::string& out_file_path, ForwardIterator hits_begin, ForwardIterator hits_end);
+void saveHitsToHDF5(const std::string& out_file_path, const std::vector<Hit>& hits);
+void saveHitsToHDF5(const std::string& out_file_path, const Hit* hits, const size_t num_hits);
+
+void saveNeutronToHDF5(const std::string out_file_path, const std::vector<Neutron>& neutrons);

--- a/sophiread/FastSophiread/include/disk_io.h
+++ b/sophiread/FastSophiread/include/disk_io.h
@@ -51,4 +51,13 @@ template <typename ForwardIterator>
 void appendHitsToHDF5(const std::string& out_file_name, ForwardIterator hits_begin, ForwardIterator hits_end);
 void appendHitsToHDF5(const std::string& out_file_name, const std::vector<Hit>& hits);
 
-void saveNeutronToHDF5(const std::string out_file_path, const std::vector<Neutron>& neutrons);
+template <typename ForwardIterator>
+void saveOrAppendNeutronToHDF5(const std::string& out_file_name, ForwardIterator neutron_begin,
+                               ForwardIterator neutron_end, bool append = false);
+template <typename ForwardIterator>
+void saveNeutronToHDF5(const std::string& out_file_name, ForwardIterator neutron_begin, ForwardIterator neutron_end);
+void saveNeutronToHDF5(const std::string& out_file_name, const std::vector<Neutron>& neutrons);
+
+template <typename ForwardIterator>
+void appendNeutronToHDF5(const std::string& out_file_name, ForwardIterator neutron_begin, ForwardIterator neutron_end);
+void appendNeutronToHDF5(const std::string& out_file_name, const std::vector<Neutron>& neutrons);

--- a/sophiread/FastSophiread/include/disk_io.h
+++ b/sophiread/FastSophiread/include/disk_io.h
@@ -34,9 +34,21 @@ std::vector<char> readTPX3RawToCharVec(const std::string& tpx3file);
 
 std::string generateFileNameWithMicroTimestamp(const std::string& originalFileName);
 
+template <typename T, typename ForwardIterator>
+void writeDatasetToGroup(H5::Group& group, const std::string& dataset_name, ForwardIterator begin, ForwardIterator end,
+                         const H5::DataType& data_type);
+
+std::string generateGroupName(H5::H5File& file, const std::string& baseName);
+
+template <typename ForwardIterator>
+void saveOrAppendHitsToHDF5(const std::string& out_file_name, ForwardIterator hits_begin, ForwardIterator hits_end,
+                            bool appendMode = false);
 template <typename ForwardIterator>
 void saveHitsToHDF5(const std::string& out_file_path, ForwardIterator hits_begin, ForwardIterator hits_end);
-
 void saveHitsToHDF5(const std::string& out_file_path, const std::vector<Hit>& hits);
+
+template <typename ForwardIterator>
+void appendHitsToHDF5(const std::string& out_file_name, ForwardIterator hits_begin, ForwardIterator hits_end);
+void appendHitsToHDF5(const std::string& out_file_name, const std::vector<Hit>& hits);
 
 void saveNeutronToHDF5(const std::string out_file_path, const std::vector<Neutron>& neutrons);

--- a/sophiread/FastSophiread/include/neutron.h
+++ b/sophiread/FastSophiread/include/neutron.h
@@ -28,6 +28,7 @@ class Neutron {
  public:
   Neutron(const double x, const double y, const double tof, const double tot, const int nHits)
       : m_x(x), m_y(y), m_tof(tof), m_tot(tot), m_nHits(nHits){};
+
   double getX() const { return m_x; };
   double getY() const { return m_y; };
   double getTOT() const { return m_tot; }
@@ -42,9 +43,9 @@ class Neutron {
   };
 
  private:
-  const double m_x, m_y;                    // pixel coordinates
-  const double m_tof;                       // time of flight
-  const double m_tot;                       // time-over-threshold
-  const int m_nHits;                        // number of hits in the event (cluster size)
-  const double m_scale_to_ns_40mhz = 25.0;  // 40 MHz clock is used for the coarse time of arrival.
+  double m_x, m_y;                    // pixel coordinates
+  double m_tof;                       // time of flight
+  double m_tot;                       // time-over-threshold
+  int m_nHits;                        // number of hits in the event (cluster size)
+  double m_scale_to_ns_40mhz = 25.0;  // 40 MHz clock is used for the coarse time of arrival.
 };

--- a/sophiread/FastSophiread/include/tpx3_fast.h
+++ b/sophiread/FastSophiread/include/tpx3_fast.h
@@ -25,6 +25,7 @@
 #include <vector>
 
 #include "hit.h"
+#include "neutron.h"
 
 /**
  * @brief Special struct to hold the information about chip dataset position in
@@ -36,6 +37,7 @@ struct TPX3 {
   const int num_packets;       // number of packets in the dataset batch (time packet and data packet)
   const int chip_layout_type;  // data source (sub-chip ID)
   std::vector<Hit> hits;       // hits extracted from the dataset batch
+  std::vector<Neutron> neutrons;  // neutrons from clustering hits
 
   unsigned long tdc_timestamp;       // starting tdc timestamp of the dataset batch
   unsigned long long gdc_timestamp;  // starting gdc timestamp of the dataset batch

--- a/sophiread/FastSophiread/src/disk_io.cpp
+++ b/sophiread/FastSophiread/src/disk_io.cpp
@@ -55,3 +55,34 @@ std::vector<char> readTPX3RawToCharVec(const std::string& tpx3file) {
 
   return vec;
 }
+
+/**
+ * @brief Append microsecond timestamp to the file name.
+ *
+ * @param[in] originalFileName
+ * @return std::string
+ */
+std::string generateFileNameWithMicroTimestamp(const std::string& originalFileName) {
+  auto now = std::chrono::high_resolution_clock::now();
+  auto seconds = std::chrono::time_point_cast<std::chrono::seconds>(now);
+  auto micros = std::chrono::duration_cast<std::chrono::microseconds>(now - seconds);
+
+  std::filesystem::path filePath(originalFileName);
+  std::string baseName = filePath.stem().string();
+  std::string extension = filePath.extension().string();
+  std::filesystem::path parentPath = filePath.parent_path();
+
+  // use h5 as extention if not specified
+  if (extension.empty()) {
+    extension = ".h5";
+  }
+
+  std::stringstream newFileName;
+  newFileName << baseName << "_" << std::setfill('0') << std::setw(6) << micros.count() << extension;
+
+  if (!parentPath.empty()) {
+    return (parentPath / newFileName.str()).string();
+  } else {
+    return newFileName.str();
+  }
+}

--- a/sophiread/FastSophiread/src/disk_io.cpp
+++ b/sophiread/FastSophiread/src/disk_io.cpp
@@ -21,6 +21,8 @@
  */
 #include "disk_io.h"
 
+#include <filesystem>
+
 #include "spdlog/spdlog.h"
 
 /**

--- a/sophiread/SophireadCLI/CMakeLists.txt
+++ b/sophiread/SophireadCLI/CMakeLists.txt
@@ -1,11 +1,13 @@
-# Configure the commandline application
-set(SRC_FILES
-    src/sophiread.cpp
-)
-
 # Include the headers
 include_directories(
-    ${PROJECT_SOURCE_DIR}/SophireadLib/include
+    include
+    ${PROJECT_SOURCE_DIR}/FastSophiread/include
+)
+
+# Configure the commandline application
+set(SRC_FILES
+    src/user_config.cpp
+    src/sophiread.cpp
 )
 
 # ----------------- CLI APPLICATION ----------------- #
@@ -13,8 +15,31 @@ add_executable(Sophiread
     ${SRC_FILES}
 )
 set_target_properties(Sophiread PROPERTIES VERSION ${PROJECT_VERSION})
-target_link_libraries(Sophiread SophireadLib hdf5 hdf5_cpp OpenMP::OpenMP_CXX)
+target_link_libraries(
+    Sophiread
+    FastSophiread
+    tbb
+    spdlog::spdlog
+    ${HDF5_LIBRARIES}
+)
 
+# ----------------- TESTS ----------------- #
+# UserConfig tests
+add_executable(
+    UserConfigTest
+    tests/test_user_config.cpp
+    src/user_config.cpp
+)
+target_link_libraries(
+    UserConfigTest
+    FastSophiread
+    spdlog::spdlog
+    GTest::GTest
+    GTest::Main
+)
+gtest_discover_tests(UserConfigTest)
+
+# ----------------- SYMLINK ----------------- #
 # symlink the executable to the build directory
 add_custom_command(TARGET Sophiread POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E create_symlink 

--- a/sophiread/SophireadCLI/include/user_config.h
+++ b/sophiread/SophireadCLI/include/user_config.h
@@ -1,0 +1,57 @@
+/**
+ * @file params.h
+ * @author Chen Zhang (zhangc@orn.gov)
+ * @author Su-Ann Chong (chongs@ornl.gov)
+ * @brief Class to store user-defined configuration for clustering algorithms.
+ * @version 0.1
+ * @date 2023-09-18
+ *
+ * @copyright Copyright (c) 2023
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <string>
+
+class UserConfig {
+ public:
+  UserConfig(){};
+  UserConfig(const double abs_radius, unsigned long int abs_min_cluster_size, unsigned long int abs_spider_time_range)
+      : m_abs_radius(abs_radius),
+        m_abs_min_cluster_size(abs_min_cluster_size),
+        m_abs_spider_time_range(abs_spider_time_range){};
+
+  double getABSRadius() const { return m_abs_radius; };
+  void setABSRadius(const double abs_radius) { m_abs_radius = abs_radius; };
+
+  unsigned long int getABSMinClusterSize() const { return m_abs_min_cluster_size; };
+  void setABSMinClusterSize(const unsigned long int abs_min_cluster_size) {
+    m_abs_min_cluster_size = abs_min_cluster_size;
+  };
+
+  unsigned long int getABSSpidertimeRange() const { return m_abs_spider_time_range; };
+  void setABSSpidertimeRange(const unsigned long int abs_spider_time_range) {
+    m_abs_spider_time_range = abs_spider_time_range;
+  };
+
+  std::string toString() const;
+
+ private:
+  // ABS members (see abs.h for details)
+  double m_abs_radius = 5.0;
+  unsigned long int m_abs_min_cluster_size = 1;
+  unsigned long int m_abs_spider_time_range = 75;
+};
+
+UserConfig parseUserDefinedConfigurationFile(const std::string& filepath);

--- a/sophiread/SophireadCLI/src/user_config.cpp
+++ b/sophiread/SophireadCLI/src/user_config.cpp
@@ -1,0 +1,103 @@
+/**
+ * @file user_config.cpp
+ * @author Chen Zhang (zhangc@orn.gov)
+ * @author Su-Ann Chong (chongs@ornl.gov)
+ * @brief Class to store user-defined configuration for clustering algorithms.
+ * @version 0.1
+ * @date 2023-09-18
+ *
+ * @copyright Copyright (c) 2023
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "user_config.h"
+
+#include <spdlog/spdlog.h>
+
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+
+/**
+ * @brief Helper function to convert a user configuration to a string for console output.
+ *
+ * @return std::string
+ */
+std::string UserConfig::toString() const {
+  std::stringstream ss;
+  ss << "ABS: radius=" << m_abs_radius << ", min_cluster_size=" << m_abs_min_cluster_size
+     << ", spider_time_range=" << m_abs_spider_time_range;
+
+  return ss.str();
+}
+
+/**
+ * @brief Parse the user-defined configuration file and return a UserConfig object.
+ *
+ * @param[in] filepath
+ * @return UserConfig
+ */
+UserConfig parseUserDefinedConfigurationFile(const std::string& filepath) {
+  // Check if the file exists
+  if (!std::filesystem::exists(filepath)) {
+    spdlog::error("The user-defined configuration file {} does not exist.", filepath);
+    exit(1);
+  }
+
+  // Create the default UserConfig object
+  UserConfig user_config;
+
+  //
+  std::ifstream user_defined_params_file(filepath);
+  if (!user_defined_params_file.is_open()) {
+    spdlog::error("Failed to open {}.", filepath);
+    spdlog::warn("Fallback to default user configurations!");
+    return user_config;
+  }
+
+  std::string line;
+  while (std::getline(user_defined_params_file, line)) {
+    std::istringstream ss(line);
+    std::string name;
+    ss >> name;
+
+    // skip comments
+    if (name[0] == '#') {
+      continue;
+    }
+
+    if (name == "abs_radius") {
+      double value;
+      ss >> value;
+      user_config.setABSRadius(value);
+    } else if (name == "abs_min_cluster_size") {
+      int value;
+      ss >> value;
+      user_config.setABSMinClusterSize(value);
+    } else if (name == "spider_time_range") {
+      int value;
+      ss >> value;
+      user_config.setABSSpidertimeRange(value);
+    } else {
+      spdlog::warn("Unknown parameter {} in the user-defined configuration file.", name);
+    }
+  }
+
+  // Close the file
+  user_defined_params_file.close();
+
+  // Print the user-defined parameters
+  spdlog::info("User-defined parameters: {}", user_config.toString());
+
+  return user_config;
+}

--- a/sophiread/SophireadCLI/tests/test_user_config.cpp
+++ b/sophiread/SophireadCLI/tests/test_user_config.cpp
@@ -1,0 +1,75 @@
+/**
+ * @file test_user_config.cpp
+ * @author Chen Zhang (zhangc@orn.gov)
+ * @brief Unit tests for UserConfig class.
+ * @version 0.1
+ * @date 2023-09-18
+ *
+ * @copyright Copyright (c) 2023
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include <gtest/gtest.h>
+
+#include <fstream>
+
+#include "user_config.h"
+
+// Test toString method of UserConfig class
+TEST(UserConfigTest, ToStringMethod) {
+  UserConfig config(20.0, 30, 500000);
+  std::string expected = "ABS: radius=20, min_cluster_size=30, spider_time_range=500000";
+  ASSERT_EQ(config.toString(), expected);
+}
+
+// Test parsing a valid configuration file
+TEST(UserConfigTest, ParseValidConfigurationFile) {
+  // Prepare a test config file
+  std::ofstream testFile("testConfig.txt");
+  testFile << "# ABS\n";
+  testFile << "abs_radius 20.0\n";
+  testFile << "abs_min_cluster_size 30\n";
+  testFile << "spider_time_range 500000\n";
+  testFile.close();
+
+  UserConfig config = parseUserDefinedConfigurationFile("testConfig.txt");
+  ASSERT_DOUBLE_EQ(config.getABSRadius(), 20.0);
+  ASSERT_EQ(config.getABSMinClusterSize(), 30);
+  ASSERT_EQ(config.getABSSpidertimeRange(), 500000);
+
+  // Cleanup
+  std::remove("testConfig.txt");
+}
+
+// Test parsing a configuration file with unknown parameters
+TEST(UserConfigTest, ParseInvalidConfigurationFile) {
+  // Prepare a test config file
+  std::ofstream testFile("testInvalidConfig.txt");
+  testFile << "# ABS\n";
+  testFile << "unknown_parameter 123.45\n";
+  testFile.close();
+
+  // It should ignore the unknown parameter and use the default value instead
+  UserConfig config = parseUserDefinedConfigurationFile("testInvalidConfig.txt");
+  ASSERT_DOUBLE_EQ(config.getABSRadius(), 5.0);   // Default value
+  ASSERT_EQ(config.getABSMinClusterSize(), 1);    // Default value
+  ASSERT_EQ(config.getABSSpidertimeRange(), 75);  // Default value
+
+  // Cleanup
+  std::remove("testInvalidConfig.txt");
+}
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
# Description of Pull Request

This PR added HDF IO support (both writing to new files as well as appending to existing one as new group) and link SophireadCLI with FastSophiread.

## Purpose of work
<!--
Why has this work been done?
If there is no linked issue please provide appropriate context for this work.
-->

1. Allow users to save parsed hits and clustered neutrons to HDF5 archive for post analysis.
2. Link `SophireadCLI` application with the latest `FastSophiread`

<!-- If the original issue was raised by a user they should be named here.
NOTE: you can use @GITHUB_USERNAME to reference a user.
-->

## Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

1. Add HDF5 support for hits.
2. Add HDF5 support for neutrons.
3. Adjust build system to link SophireadCLI with FastSophiread.

## Additional detail of work
<!-- [Optional] If there is additional detail that is relevant to this PR, please provide it here.
-->

N/A

## Testing instructions

- build the branch
- run `ctest -V --output-on-failure`
- use the new command line application `Sophiread` to parse static tpx3 file.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

Fixes #32 .
<!-- and fix #xxxx or close #xxxx xor resolves #xxxx 
NOTE: skip this part if not applicable to your PR.
-->
