### PR TITLE
Fix issue where data is saved to H5 with incorrect data type

### DIFF
--- a/sophiread/FastSophiread/src/disk_io.cpp
+++ b/sophiread/FastSophiread/src/disk_io.cpp
@@ -192,17 +192,17 @@ void saveOrAppendToHDF5(
 template <typename ForwardIterator>
 void saveOrAppendHitsToHDF5(const std::string &out_file_name, ForwardIterator hits_begin, ForwardIterator hits_end,
                             bool append) {
-  saveOrAppendToHDF5<int>(out_file_name, hits_begin, hits_end, "hits",
-                          {
-                              {"x", [](const auto &hit) { return hit.getX(); }},
-                              {"y", [](const auto &hit) { return hit.getY(); }},
-                              {"tot_ns", [](const auto &hit) { return hit.getTOT_ns(); }},
-                              {"toa_ns", [](const auto &hit) { return hit.getTOA_ns(); }},
-                              {"ftoa_ns", [](const auto &hit) { return hit.getFTOA_ns(); }},
-                              {"tof_ns", [](const auto &hit) { return hit.getTOF_ns(); }},
-                              {"spidertime_ns", [](const auto &hit) { return hit.getSPIDERTIME_ns(); }},
-                          },
-                          append);
+  saveOrAppendToHDF5<double>(out_file_name, hits_begin, hits_end, "hits",
+                             {
+                                 {"x", [](const auto &hit) { return static_cast<double>(hit.getX()); }},
+                                 {"y", [](const auto &hit) { return static_cast<double>(hit.getY()); }},
+                                 {"tot_ns", [](const auto &hit) { return hit.getTOT_ns(); }},
+                                 {"toa_ns", [](const auto &hit) { return hit.getTOA_ns(); }},
+                                 {"ftoa_ns", [](const auto &hit) { return hit.getFTOA_ns(); }},
+                                 {"tof_ns", [](const auto &hit) { return hit.getTOF_ns(); }},
+                                 {"spidertime_ns", [](const auto &hit) { return hit.getSPIDERTIME_ns(); }},
+                             },
+                             append);
 }
 
 /**


### PR DESCRIPTION
# Description of Pull Request

This PR provide a temp fix to the issue where incorrect data type is used when using to HDF5 archive.

## Purpose of work
<!--
Why has this work been done?
If there is no linked issue please provide appropriate context for this work.
-->

Provide a temporary fix to the data type issue while looking for a permanent solution where heterogeneous dataset can be saved/appended to the same group.

<!-- If the original issue was raised by a user they should be named here.
NOTE: you can use @GITHUB_USERNAME to reference a user.
-->

## Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

1. Add checks to the single thread run in benchmark_raw2events for easy evaluation.
2. Force all data saved to HDF5 to be double for the moment.

## Additional detail of work
<!-- [Optional] If there is additional detail that is relevant to this PR, please provide it here.
-->

N/A

## Testing instructions

1. Build the branch
2. Run CTEST
3. Run the benchmark and confirm that correct max spider time can be read from disk

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

Fixes #42 .
<!-- and fix #xxxx or close #xxxx xor resolves #xxxx 
NOTE: skip this part if not applicable to your PR.
-->
