### PR TITLE
Resolve discrepancy related to spidertime and tof

### DIFF
--- a/sophiread/FastSophiread/src/hit.cpp
+++ b/sophiread/FastSophiread/src/hit.cpp
@@ -64,12 +64,7 @@ Hit::Hit(const char *packet, const unsigned long long TDC_timestamp, const unsig
 
   // additional check to make sure rollover of spidertime is correct 
   if ((m_spidertime-GDC_timestamp)>=4e7){
-    // std::cout << "potentially incorrect rollover\n"; 
-    // std::cout << "spidertime: " << m_spidertime*25e-9 
-    //           << "\t gdc: " << GDC_timestamp*25e-9 
-    //           << std::endl;
     m_spidertime -= 1073741824;
-    // std::cout << "updated spidertime: " << m_spidertime*25e-9 << std::endl;
   }
 
   // tof calculation
@@ -80,10 +75,10 @@ Hit::Hit(const char *packet, const unsigned long long TDC_timestamp, const unsig
     m_tof = m_spidertime - TDC_timestamp;
   }
 
-  // some error in SPIDR_timestamp (revisit this fix)
-  if (m_tof*25E-6 > 16.67){
-    m_tof = m_tof - 1073741824;
-  }
+  // // some error in SPIDR_timestamp (revisit this fix)
+  // if (m_tof*25E-6 > 16.67){
+  //   m_tof = m_tof - 1073741824;
+  // }
 
   // pixel address
   npixaddr = (unsigned int *)(&packet[4]);  // Pixel address (14 bits)

--- a/sophiread/FastSophiread/src/hit.cpp
+++ b/sophiread/FastSophiread/src/hit.cpp
@@ -21,6 +21,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include "hit.h"
+#include <iostream>
 
 /**
  * @brief Special constructor that construct a Hit from raw bytes.
@@ -62,8 +63,13 @@ Hit::Hit(const char *packet, const unsigned long long TDC_timestamp, const unsig
   m_spidertime = m_spidertime | spidertime;
 
   // additional check to make sure rollover of spidertime is correct 
-  if (abs(m_spidertime-GDC_timestamp)=>1.0){
+  if ((m_spidertime-GDC_timestamp)>=4e7){
+    // std::cout << "potentially incorrect rollover\n"; 
+    // std::cout << "spidertime: " << m_spidertime*25e-9 
+    //           << "\t gdc: " << GDC_timestamp*25e-9 
+    //           << std::endl;
     m_spidertime -= 1073741824;
+    // std::cout << "updated spidertime: " << m_spidertime*25e-9 << std::endl;
   }
 
   // tof calculation

--- a/sophiread/FastSophiread/src/hit.cpp
+++ b/sophiread/FastSophiread/src/hit.cpp
@@ -63,27 +63,17 @@ Hit::Hit(const char *packet, const unsigned long long TDC_timestamp, const unsig
   m_spidertime = m_spidertime | spidertime;
 
   // additional check to make sure rollover of spidertime is correct 
+  // 4e7 is roughly 1 second in the units of 25 ns
+  // 1073741824 is 2^30 (in units of 25 ns)
   if ((m_spidertime-GDC_timestamp)>=4e7){
     m_spidertime -= 1073741824;
   }
 
   // tof calculation
   m_tof = m_spidertime - TDC_timestamp;
-
   while (m_tof*25E-6 > 16.67){
     m_tof -= 666667;
   }
-  // // TDC packets not always arrive before corresponding data packets
-  // if (m_spidertime < TDC_timestamp) {
-  //   m_tof = m_spidertime - TDC_timestamp + 666667;
-  // } else {
-  //   m_tof = m_spidertime - TDC_timestamp;
-  // }
-
-  // // some error in SPIDR_timestamp (revisit this fix)
-  // if (m_tof*25E-6 > 16.67){
-  //   m_tof = m_tof - 1073741824;
-  // }
 
   // pixel address
   npixaddr = (unsigned int *)(&packet[4]);  // Pixel address (14 bits)

--- a/sophiread/FastSophiread/src/hit.cpp
+++ b/sophiread/FastSophiread/src/hit.cpp
@@ -61,6 +61,11 @@ Hit::Hit(const char *packet, const unsigned long long TDC_timestamp, const unsig
   m_spidertime = (SPDR_MSB18 << 30) & 0xFFFFC0000000;
   m_spidertime = m_spidertime | spidertime;
 
+  // additional check to make sure rollover of spidertime is correct 
+  if (abs(m_spidertime-GDC_timestamp)=>1.0){
+    m_spidertime -= 1073741824;
+  }
+
   // tof calculation
   // TDC packets not always arrive before corresponding data packets
   if (m_spidertime < TDC_timestamp) {

--- a/sophiread/FastSophiread/src/hit.cpp
+++ b/sophiread/FastSophiread/src/hit.cpp
@@ -68,12 +68,17 @@ Hit::Hit(const char *packet, const unsigned long long TDC_timestamp, const unsig
   }
 
   // tof calculation
-  // TDC packets not always arrive before corresponding data packets
-  if (m_spidertime < TDC_timestamp) {
-    m_tof = m_spidertime - TDC_timestamp + 666667;
-  } else {
-    m_tof = m_spidertime - TDC_timestamp;
+  m_tof = m_spidertime - TDC_timestamp;
+
+  while (m_tof*25E-6 > 16.67){
+    m_tof -= 666667;
   }
+  // // TDC packets not always arrive before corresponding data packets
+  // if (m_spidertime < TDC_timestamp) {
+  //   m_tof = m_spidertime - TDC_timestamp + 666667;
+  // } else {
+  //   m_tof = m_spidertime - TDC_timestamp;
+  // }
 
   // // some error in SPIDR_timestamp (revisit this fix)
   // if (m_tof*25E-6 > 16.67){


### PR DESCRIPTION
# Description of Pull Request

## Purpose of work
<!--
Why has this work been done?
If there is no linked issue please provide appropriate context for this work.
-->

This PR introduces correction to the jumps in `spidertime` and resolves the overflow issues of `tof`. A new dataset (`HV2700_1500_500_THLrel_274_sophy_chopper_60Hz_4.1mm_aperture_siemen_star_120s_000000.tpx3`) was added to `resource/data`. This dataset is a 120-s run on a Siemen star resolution mask with chopper operating at 60Hz taken at MARS Sept 2023. 

Testing instruction:
1. build feature branch.
2. Run `ctest -v` should pass all testcases. 
3. Run `./FastSophireadBenchmarks_raw2events.app data/HV2700_1500_500_THLrel_274_sophy_chopper_60Hz_4.1mm_aperture_siemen_star_120s_000000.tpx3`. There should be no bad hits recorded. 


Fixes #47 