### PR TITLE
Minor fix 44 bits to 48 bits check for GDC packet

### DIFF
--- a/sophiread/FastSophiread/src/tpx3_fast.cpp
+++ b/sophiread/FastSophiread/src/tpx3_fast.cpp
@@ -208,7 +208,7 @@ void update_gdc_timestamp_and_timer_lsb32(const char *char_array, unsigned long 
 
   // process given GDC packet
   gdclast = (unsigned long *)(&char_array[0]);
-  mygdc = (((*gdclast) >> 16) & 0xFFFFFFFFFFF);
+  mygdc = (((*gdclast) >> 16) & 0xFFFFFFFFFFFF);
 
   switch (((mygdc >> 40) & 0xF)) {
     case 0x4:

--- a/sophiread/SophireadLib/src/tpx3.cpp
+++ b/sophiread/SophireadLib/src/tpx3.cpp
@@ -370,7 +370,7 @@ std::vector<Hit> readTimepix3RawData(const std::string &filepath) {
         } else if ((data_packet[7] & 0xF0) == 0x40) {
           // GDC data packet
           gdclast = (unsigned long *)(&data_packet[0]);
-          mygdc = (((*gdclast) >> 16) & 0xFFFFFFFFFFF);
+          mygdc = (((*gdclast) >> 16) & 0xFFFFFFFFFFFF);
           if (((mygdc >> 40) & 0xF) == 0x4) {
             Timer_LSB32 = mygdc & 0xFFFFFFFF;  // 32-bit
           } else if (((mygdc >> 40) & 0xF) == 0x5) {


### PR DESCRIPTION
# Description of Pull Request

Address issue #49 where we checked the remaining 48 bits instead of 44 bits after shifting right by 16 bits for a 64-bit data packet. This change does not affect the parsing of GDC packet, this PR is just made just so it makes sense for general users who wish to take a deep dive into the logic of processing raw data. 

## Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

In [ line](https://github.com/ornlneutronimaging/mcpevent2hist/blob/9b7d1932243d588d1004a8c5fbfa5b3c87eb5d0a/sophiread/FastSophiread/src/tpx3_fast.cpp#L211C36-L211C46) , `0xFFFFFFFFFFF` (44 bits) is changed to `0xFFFFFFFFFFFF` (48 bits). 

## Testing instructions

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

- Build feature branch
- Run `ctest -v` should pass all testcases. 

Fixes #49 .
<!-- and fix #xxxx or close #xxxx xor resolves #xxxx 
NOTE: skip this part if not applicable to your PR.
-->
