### PR TITLE
Provide support for memory mapped operation

### DIFF
--- a/sophiread/FastSophiread/CMakeLists.txt
+++ b/sophiread/FastSophiread/CMakeLists.txt
@@ -169,3 +169,25 @@ add_custom_command(TARGET SophireadBenchmarks_raw2events POST_BUILD
     ${PROJECT_BINARY_DIR}/FastSophiread/SophireadBenchmarks_raw2events
     ${PROJECT_BINARY_DIR}/FastSophireadBenchmarks_raw2events.app
 )
+# CLI
+add_executable(
+    FastSophireadBenchmarksCLI
+    benchmarks/benchmark_mmap.cpp
+)
+target_link_libraries(
+    FastSophireadBenchmarksCLI
+    FastSophiread
+    pthread
+    tbb
+    spdlog::spdlog
+    ${HDF5_LIBRARIES}
+)
+add_custom_command(TARGET FastSophireadBenchmarksCLI POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E create_symlink
+    ${PROJECT_BINARY_DIR}/FastSophiread/FastSophireadBenchmarksCLI
+    ${PROJECT_BINARY_DIR}/FastSophireadBenchmarksCLI.app
+
+    COMMAND ${CMAKE_COMMAND} -E create_symlink
+    ${PROJECT_SOURCE_DIR}/FastSophiread/benchmarks/benchmark.sh
+    ${PROJECT_BINARY_DIR}/FastSophiread_benchmark.sh
+)

--- a/sophiread/FastSophiread/benchmarks/benchmark.sh
+++ b/sophiread/FastSophiread/benchmarks/benchmark.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+# Process all .tpx3 files in data/ (that have GDC timestamps...)
+#
+# usage:
+#   $0 [output-file-extention [number-of-iterations] ]
+#
+# where:
+#   output-file-extention is either { h5, csv, or bin } as supported by FastSophireadBenchmarksCLI.app (default h5)
+#   number-of-iterations is how many times to repeat a clustering to obtain stable performance metrics (default 3)
+#
+# description:
+#   The program processes .tpx3 files under a variety of parameters (w/ and w/o memory mapping, primarily)
+# it produces data output files of clustered events for every iteration, collects information on the time used
+# in each iteration, and compares the result of each iteration to check that the same answers are obtained.
+
+EXT=${1:-h5}
+LST="data/suann_socket_background_serval32.tpx3 data/HV2700_1500_500_THLrel_274_sophy_chopper_60Hz_4.1mm_aperture_siemen_star_120s_000000.tpx3"
+ITR=${2:-3}
+
+# meaningful comparisons of hdf5 files requires h5diff
+if [ "$EXT" == "h5" ] ; then
+    DIFF="h5diff -v"
+elif [ "$EXT" == "bin" ] ; then
+    DIFF="diff -bq"
+else
+    DIFF="diff -s"
+fi
+
+for f in $LST ; do
+    x=$(basename $f)
+    y=${x%.*}
+    result=result/$y
+    mkdir -p $result
+    # need a fixed output for comparisons
+    echo "*** baseline output for $x"
+
+    # TODO: the Sophiread program produces an .h5 file that slightly differs from app, so cannot be used at the moment
+    #
+    # Not comparable: </neutrons/nHits> is of class H5T_FLOAT and </neutrons/nHits> is of class H5T_INTEGER
+    # Not comparable: </neutrons/tof> has rank 1, dimensions [190208], max dimensions [190208]
+    #   and </neutrons/tof> has rank 1, dimensions [190207], max dimensions [190207]
+    # ...
+    # seems like some minor adjustments are needed
+
+    ##if [ "$EXT" == "h5" ] ; then
+    ##    ./Sophiread -i $f -E ${result}/${y}.verify.h5 ;
+    ##else
+        ./FastSophireadBenchmarksCLI.app $f ${result}/${y}.verify.${EXT} verify+tgdc
+    ##fi
+    echo ""
+    for m in stream mmap ; do
+        for c in tbb verify ; do
+            CFG=${m}+${c}+tgdc
+            #echo "" > ${result}/${CFG}.info
+            echo "" > ${result}/${CFG}.result
+            echo "*** ${result}/${CFG} ***"
+            for i in $(seq 1 ${ITR}) ; do
+                echo "${CFG} try ${i}:" >> ${result}/${CFG}.info
+                (time ./FastSophireadBenchmarksCLI.app $f ${result}/${y}.${CFG}.${i}.${EXT} ${CFG}) 2>>${result}/${CFG}.result >> ${result}/${CFG}.info
+            done
+            echo "${CFG} real time summary:" >> ${result}/${CFG}.info
+            grep real ${result}/${CFG}.result >> ${result}/${CFG}.info
+            echo "" >> ${result}/${CFG}.info
+        done
+    done
+done
+echo ""
+
+echo "" > result/verify.info
+echo "*** inspecting results of .${EXT} files produced ***"
+differences=0
+total=0
+for f in $(find result -name "*.${EXT}") ; do
+    d=$(dirname $f)
+    b=$(basename $d)
+    if [ -e ${d}/${b}.verify.${EXT} ] ; then
+        total=$(($total + 1))
+	echo "*** Compare ${d}/${b}.verify.${EXT} $f ***" >> result/verify.info
+        if ( $DIFF ${d}/${b}.verify.${EXT} $f >> result/verify.info ) ; then
+            echo "*** 0 exit code (no differences) ***" >> result/verify.info
+	else
+            differences=$(($differences + 1))
+            echo "*** DIFFERENCES IDENTIFIED ***" >> result/verify.info
+	fi
+	echo "" >> result/verify.info
+    fi
+done
+if (( $total == 0 )) ; then
+    echo "NO FILEs were inspected; cannot comment on results"
+elif (( $differences == 0 )) ; then
+    echo "ALL $total result files matched for every iteration"
+else
+    echo "$differences/$total mis-matched see result/verify.info for details"
+fi
+echo ""
+
+echo "" > result/speed.info
+echo "*** report statistics on recorded benchmarks ***"
+# https://unix.stackexchange.com/questions/24140/return-only-the-portion-of-a-line-after-a-matching-pattern
+# https://stackoverflow.com/questions/9789806/command-line-utility-to-print-statistics-of-numbers-in-linux
+# https://unix.stackexchange.com/questions/13731/is-there-a-way-to-get-the-min-max-median-and-average-of-a-list-of-numbers-in
+( find result -type f -exec grep "Single-Thread" {} /dev/null \; ) | sed -n -e 's/^.*Single-Thread speed: //p' | sort -u | cut -f1 -d' ' > result/single-thread.csv
+( find result -type f -exec grep "TBB Parallel" {} /dev/null \; ) | sed -n -e 's/^.*TBB Parallel speed: //p' | sort -u | cut -f1 -d' ' > result/tbb.csv
+for f in result/*.csv ; do
+    if [ -z "$(which R 2>/dev/null)" ] ; then
+        echo "$f: (hits/sec)" | tee -a result/speed.info
+        cat $f | python3 -c "import fileinput,statistics; i = [float(l.strip()) for l in fileinput.input()]; print('min:', f'{int(min(i)):,}', 'median:', f'{int(statistics.median(i)):,}', 'mean:', f'{int(statistics.mean(i)):,}', 'max:', f'{int(max(i)):,}')" | tee -a result/speed.info
+        echo "" | tee -a result/speed.info
+    else
+        # R replicates its code and produces a newline
+        # https://stackoverflow.com/questions/1581232/add-commas-into-number-for-output
+        cat $f | R -q -e "formatC(summary(as.numeric(read.table(\"${f}\")[,1])),format=\"d\",big.mark=\",\")" | tee -a result/speed.info
+    fi
+done

--- a/sophiread/FastSophiread/benchmarks/benchmark.sh
+++ b/sophiread/FastSophiread/benchmarks/benchmark.sh
@@ -52,7 +52,6 @@ for f in $LST ; do
     for m in stream mmap ; do
         for c in tbb verify ; do
             CFG=${m}+${c}+tgdc
-            #echo "" > ${result}/${CFG}.info
             echo "" > ${result}/${CFG}.result
             echo "*** ${result}/${CFG} ***"
             for i in $(seq 1 ${ITR}) ; do

--- a/sophiread/FastSophiread/benchmarks/benchmark.sh
+++ b/sophiread/FastSophiread/benchmarks/benchmark.sh
@@ -14,7 +14,8 @@
 # in each iteration, and compares the result of each iteration to check that the same answers are obtained.
 
 EXT=${1:-h5}
-LST="data/suann_socket_background_serval32.tpx3 data/HV2700_1500_500_THLrel_274_sophy_chopper_60Hz_4.1mm_aperture_siemen_star_120s_000000.tpx3"
+# TODO: data/suann_socket_background_serval32.tpx3 produces poor performance statistics
+LST="data/HV2700_1500_500_THLrel_274_sophy_chopper_60Hz_4.1mm_aperture_siemen_star_120s_000000.tpx3"
 ITR=${2:-3}
 
 # meaningful comparisons of hdf5 files requires h5diff

--- a/sophiread/FastSophiread/benchmarks/benchmark_mmap.cpp
+++ b/sophiread/FastSophiread/benchmarks/benchmark_mmap.cpp
@@ -106,8 +106,6 @@ void saveEventsToCSV(const std::string out_file_name, const std::vector<Neutron>
   // sanity check
   if (events.size() == 0) return;
 
-  // TODO: sort events by TOF
-  
   // write to CSV file
   // -- preparation and header
   std::ofstream file(out_file_name, std::ofstream::app);
@@ -146,8 +144,6 @@ void saveEventsToBIN(const std::string out_file_name, const std::vector<Neutron>
   // sanity check
   if (events.size() == 0) return;
 
-  // TODO: sort events by TOF
-  
   // write to BIN file
   // -- preparation and header
   std::ofstream file(out_file_name, std::ofstream::binary | std::ofstream::trunc);

--- a/sophiread/FastSophiread/benchmarks/benchmark_mmap.cpp
+++ b/sophiread/FastSophiread/benchmarks/benchmark_mmap.cpp
@@ -23,6 +23,7 @@
 #include <chrono>
 #include <fstream>
 #include <iostream>
+#include <cstdint>  // for std::numeric_limits<>
 
 #include "disk_io.h"
 #include "hit.h"
@@ -132,8 +133,6 @@ void saveEventsToCSV(const std::string out_file_name, const std::vector<Neutron>
   // -- close file
   file.close();
 }
-
-#include <cstdint>  // for std::numeric_limits<>
 
 void saveEventsToBIN( const std::string out_file_name,
                       const std::vector<Neutron>& events);

--- a/sophiread/FastSophiread/benchmarks/benchmark_mmap.cpp
+++ b/sophiread/FastSophiread/benchmarks/benchmark_mmap.cpp
@@ -260,7 +260,7 @@ int main(int argc, char* argv[])
   unsigned long timer_lsb32 = 0;
 
   // output data
-  std::vector<std::vector<Neutron>> events;
+  tbb::concurrent_vector<std::vector<Neutron>> events;
   std::string method_events;
 
   spdlog::debug("@{:p}, {}", raw_data.map, raw_data.max);
@@ -319,7 +319,7 @@ while (raw_data_consumed < raw_data.max) {
       std::vector<TPX3>& batch;
 
       // output vector-of-vector-of-events
-      std::vector<std::vector<Neutron>> output;
+      tbb::concurrent_vector<std::vector<Neutron>> output;
 
       // standard and splitting constructor
       ComputeEvents(char *input, std::size_t range, std::vector<TPX3>& batch) : input(input), range(range), batch(batch), output() {}

--- a/sophiread/FastSophiread/benchmarks/benchmark_mmap.cpp
+++ b/sophiread/FastSophiread/benchmarks/benchmark_mmap.cpp
@@ -1,0 +1,449 @@
+/**
+ * @file benchmark_mmap.cpp
+ * @author Chen Zhang (zhangc@ornl.gov) + contributors
+ * @brief Demonstrate memory-mapped processing converting raw data to events and output.
+ * @version 0.2.1
+ * @date 2024-01-30
+ *
+ * @copyright Copyright (c) 2023
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <chrono>
+#include <fstream>
+#include <iostream>
+
+#include "disk_io.h"
+#include "hit.h"
+#include "spdlog/spdlog.h"
+#include "abs.h"
+#include "tbb/tbb.h"
+#include "tpx3_fast.h"
+
+// from SophireadLib/include/tpx3.cpp
+#include <H5Cpp.h>
+#include "neutron.h"
+void saveEventsToHDF5(const std::string out_file_name,
+                      const std::vector<Neutron>& events);
+/**
+ * @brief Save events to HDF5 file.
+ *
+ * NOTE: it does not appear that this function produces reliable output data.
+ * The files are not identical from run-to-run (despite the events being identical)
+ * The resulting .h5 file does not load correctly in hdfview (at least I don't know how to see the vectors in it).
+ *
+ * TODO: There is another program Sophiread that also writes out events.  Make sure that those match up.
+ * Better still, use common output writing routines for both programs.
+ * 
+ * @param out_file_name: output file name.
+ * @param events: neutron events to be saved.
+ */
+void saveEventsToHDF5(const std::string out_file_name, const std::vector<Neutron> &events) {
+  // sanity check
+  if (events.size() == 0) return;
+
+  // write to HDF5 file
+  // -- preparation
+  H5::H5File out_file(out_file_name, H5F_ACC_TRUNC);
+  hsize_t dims[1] = {events.size()};
+  H5::DataSpace dataspace(1, dims);
+  H5::IntType int_type(H5::PredType::NATIVE_INT);
+  H5::FloatType float_type(H5::PredType::NATIVE_DOUBLE);
+  // -- make events as a group
+  H5::Group group = out_file.createGroup("neutrons");
+  // -- write x
+  std::vector<double> x(events.size());
+  std::transform(events.begin(), events.end(), x.begin(), [](const Neutron &event) { return event.getX(); });
+  H5::DataSet x_dataset = group.createDataSet("x", float_type, dataspace);
+  x_dataset.write(x.data(), float_type);
+  // -- write y
+  std::vector<double> y(events.size());
+  std::transform(events.begin(), events.end(), y.begin(), [](const Neutron &event) { return event.getY(); });
+  H5::DataSet y_dataset = group.createDataSet("y", float_type, dataspace);
+  y_dataset.write(y.data(), float_type);
+  // -- write TOF_ns
+  std::vector<double> tof_ns(events.size());
+  std::transform(events.begin(), events.end(), tof_ns.begin(),
+                 [](const Neutron &event) { return event.getTOF_ns(); });
+  H5::DataSet tof_ns_dataset = group.createDataSet("tof", float_type, dataspace);
+  tof_ns_dataset.write(tof_ns.data(), float_type);
+  // -- write Nhits
+  std::vector<int> nhits(events.size());
+  std::transform(events.begin(), events.end(), nhits.begin(),
+                 [](const Neutron &event) { return event.getNHits(); });
+  H5::DataSet nhits_dataset = group.createDataSet("nHits", int_type, dataspace);
+  nhits_dataset.write(nhits.data(), int_type);
+  // -- write TOT
+  std::vector<double> tot(events.size());
+  std::transform(events.begin(), events.end(), tot.begin(), [](const Neutron &event) { return event.getTOT(); });
+  H5::DataSet tot_dataset = group.createDataSet("tot", float_type, dataspace);
+  tot_dataset.write(tot.data(), float_type);
+  // -- close file
+  out_file.close();
+}
+
+void saveEventsToCSV( const std::string out_file_name,
+                      const std::vector<Neutron>& events);
+/**
+ * @brief Save events to CSV file.
+ *
+ * @param out_file_name: output file name.
+ * @param events: neutron events to be saved.
+ */
+void saveEventsToCSV(const std::string out_file_name, const std::vector<Neutron> &events) {
+  // sanity check
+  if (events.size() == 0) return;
+
+  // TODO: sort events by TOF
+  
+  // write to CSV file
+  // -- preparation and header
+  std::ofstream file(out_file_name, std::ofstream::app);
+
+  // Check if file is open successfully
+  if (!file.is_open()) {
+    spdlog::error("Failed to open file: {}", out_file_name);
+    exit(EXIT_FAILURE);
+  }
+
+  file << "X,Y,TOF (ns),Nhits, TOT\n";
+
+  // write events
+  for (auto & event : events) {
+    file <<
+      event.getX() << "," <<
+      event.getY() << "," <<
+      event.getTOF_ns() << "," <<
+      event.getNHits() << "," <<
+      event.getTOT() << "\n";
+  }
+
+  // -- close file
+  file.close();
+}
+
+#include <cstdint>  // for std::numeric_limits<>
+
+void saveEventsToBIN( const std::string out_file_name,
+                      const std::vector<Neutron>& events);
+/**
+ * @brief Save events to BIN file.
+ *
+ * @param out_file_name: output file name.
+ * @param events: neutron events to be saved.
+ */
+void saveEventsToBIN(const std::string out_file_name, const std::vector<Neutron> &events) {
+  // sanity check
+  if (events.size() == 0) return;
+
+  // TODO: sort events by TOF
+  
+  // write to BIN file
+  // -- preparation and header
+  std::ofstream file(out_file_name, std::ofstream::binary | std::ofstream::trunc);
+
+  // Check if file is open successfully
+  if (!file.is_open()) {
+    spdlog::error("Failed to open file: {}", out_file_name);
+    exit(EXIT_FAILURE);
+  }
+
+  // write events
+  for (auto & event : events)
+  {
+    std::uint16_t x = (std::uint16_t)(event.getX() * std::numeric_limits<uint16_t>::max()/512.0);
+    std::uint16_t y = (std::uint16_t)(event.getY() * std::numeric_limits<uint16_t>::max()/512.0);
+    std::uint64_t tof = (std::uint64_t)event.getTOF_ns();
+    std::uint16_t nhits = (std::uint16_t)event.getNHits();
+    std::uint16_t tot = (std::uint16_t)event.getTOT();
+
+    file << x << y << tof << nhits << tot;
+  }
+
+  // -- close file
+  file.close();
+}
+
+// https://stackoverflow.com/questions/874134/find-out-if-string-ends-with-another-string-in-c
+bool endsWith (std::string const &fullString, std::string const &ending) {
+    if (fullString.length() >= ending.length()) {
+        return (0 == fullString.compare (fullString.length() - ending.length(), ending.length(), ending));
+    } else {
+        return false;
+    }
+}
+
+int main(int argc, char* argv[])
+{
+  if (argc < 2) {
+    spdlog::critical("Usage: {} <input file> [<output file> [options]]", argv[0]);
+    return 1;
+  }
+
+  // parameters
+  std::string in_tpx3 = argv[1];
+  std::string out_dat = (argc > 2) ? argv[2] : "";
+  bool no_output = (argc > 2) ? false : true;
+
+  // no options implies single-thread
+  bool use_tbb = false;
+  // mmap controls memory mapping or alloc+read
+  bool use_mmap = false;
+  bool use_tgdc = false;
+  bool debug = false;
+  float pulse_rate = 0.0;
+  if( argc>3 )
+  {
+      use_tbb = strstr(argv[3],"tbb")!=NULL;
+      use_mmap = strstr(argv[3],"mmap")!=NULL;
+      use_tgdc = strstr(argv[3],"tgdc")!=NULL;
+      debug = strstr(argv[3],"debug")!=NULL;
+
+      // select pulse rate
+      pulse_rate = strstr(argv[3],"1hz")  ? 1.0  : pulse_rate;
+      pulse_rate = strstr(argv[3],"10hz") ? 10.0 : pulse_rate;
+      pulse_rate = strstr(argv[3],"15hz") ? 15.0 : pulse_rate;
+      pulse_rate = strstr(argv[3],"30hz") ? 30.0 : pulse_rate;
+      pulse_rate = strstr(argv[3],"45hz") ? 45.0 : pulse_rate;
+      pulse_rate = strstr(argv[3],"60hz") ? 60.0 : pulse_rate;
+  }
+
+  if( debug ) spdlog::set_level(spdlog::level::debug);
+
+  // report statistics
+  size_t n_hits = 0;
+  int n_bad_hits = 0;
+  size_t n_events = 0;
+
+  // manage timers (for statistics)
+  // but see also NOTES section of https://en.cppreference.com/w/cpp/chrono/high_resolution_clock
+  enum {
+    TOTAL = 0,
+    RAW_DATA,
+    BATCHES,
+    EVENTS,
+    GATHER,
+    OUTPUT,
+    NUM_TIMERS
+  };
+  struct {
+    std::chrono::time_point<std::chrono::high_resolution_clock> begin;
+    std::chrono::time_point<std::chrono::high_resolution_clock> end;
+    double accumulated;
+  } timer[NUM_TIMERS];
+  for (auto& a : timer) {
+    a.accumulated = 0.0;
+  }
+
+  // obtain pointer to data
+  std::string method_raw_data = use_mmap ? "Mapping" : "Reading";
+  spdlog::debug("{} input: {}", method_raw_data, in_tpx3);
+  timer[TOTAL].begin = timer[RAW_DATA].begin = std::chrono::high_resolution_clock::now();
+  auto raw_data = use_mmap ? mmapTPX3RawToMapInfo(in_tpx3) : readTPX3RawToMapInfo(in_tpx3);
+  timer[RAW_DATA].end = std::chrono::high_resolution_clock::now();
+  timer[RAW_DATA].accumulated = static_cast<double>(std::chrono::duration_cast<std::chrono::microseconds>(timer[RAW_DATA].end - timer[RAW_DATA].begin).count());
+
+  size_t raw_data_consumed = 0;
+  unsigned long tdc_timestamp = 0;
+  unsigned long long int gdc_timestamp = 0;
+  unsigned long timer_lsb32 = 0;
+
+  // output data
+  std::vector<std::vector<Neutron>> events;
+  std::string method_events;
+
+  spdlog::debug("@{:p}, {}", raw_data.map, raw_data.max);
+
+  if ( raw_data.map == NULL )
+  {
+    spdlog::error("Insufficient memory: {}", in_tpx3);
+    exit(EXIT_FAILURE);
+  }
+
+// NB: processing large memory-mapped files requires a restriction
+// on the amount of raw data that is treated by the algorithm
+
+  if( use_tbb )
+  {
+    spdlog::debug("Processing tbb...");
+    method_events = "TBB Parallel";
+  } else {
+    spdlog::debug("Processing single-thread...");
+    method_events = "Single-Thread";
+  }
+
+  std::cerr << std::endl;
+  std::cerr.precision(2);
+
+while (raw_data_consumed < raw_data.max) {
+
+  // manage partial batches
+  size_t consumed = 0;
+  char *raw_data_ptr = raw_data.map + raw_data_consumed;
+  size_t raw_data_size = raw_data.max - raw_data_consumed;
+
+  //spdlog::debug("raw_data: {}/{} ({:.2}%)", raw_data_consumed, raw_data.max, static_cast<double>(raw_data_consumed)*100.0/static_cast<double>(raw_data.max));
+  std::cerr << "\rraw_data: "
+            << raw_data_consumed << "/" << raw_data.max
+            << " (" << static_cast<double>(raw_data_consumed)*100.0/static_cast<double>(raw_data.max) << "%)";
+
+  timer[BATCHES].begin = std::chrono::high_resolution_clock::now();
+  auto batches = findTPX3H(raw_data_ptr, raw_data_size, consumed);
+  if (use_tgdc)
+  {
+    // extract tdc and gdc timestamps from the batches read so far
+    for (auto& tpx3 : batches) {
+      updateTimestamp(tpx3, raw_data_ptr, consumed, tdc_timestamp, gdc_timestamp, timer_lsb32);
+    }
+  }
+  timer[BATCHES].end = timer[EVENTS].begin = std::chrono::high_resolution_clock::now();
+
+  if( use_tbb )
+  {
+    // https://github.com/jjallaire/TBB/blob/master/inst/examples/parallel-vector-sum.cpp
+    struct ComputeEvents {
+      // source vector(s)
+      char *input;
+      std::size_t range;
+      std::vector<TPX3>& batch;
+
+      // output vector-of-vector-of-events
+      std::vector<std::vector<Neutron>> output;
+
+      // standard and splitting constructor
+      ComputeEvents(char *input, std::size_t range, std::vector<TPX3>& batch) : input(input), range(range), batch(batch), output() {}
+      ComputeEvents(ComputeEvents& body, tbb::split) : input(body.input), range(body.range), batch(body.batch), output() {}
+
+      // generate just the range of hits
+      void operator()(const tbb::blocked_range<size_t>& r) {
+        auto abs_alg_mt = std::make_unique<ABS>(5.0, 1, 75);
+        for (size_t i = r.begin(); i != r.end(); ++i) {
+          TPX3& _tpx3 = batch[i];
+          extractHits(_tpx3, input, range);
+          abs_alg_mt->reset();
+          abs_alg_mt->fit(_tpx3.hits);
+          output.push_back(abs_alg_mt->get_events(_tpx3.hits));
+        }
+      }
+
+      // join vectors
+      void join(ComputeEvents& rhs) {
+        for (auto& a : rhs.output) {
+          output.push_back(a);
+        }
+      }
+    };
+
+    ComputeEvents compute(raw_data_ptr, consumed, batches);
+    tbb::parallel_reduce(tbb::blocked_range<size_t>(0, batches.size()), compute);
+    // transfer vectors
+    for (auto& a : compute.output) {
+      events.push_back(a);
+    }
+  } else {
+    auto abs_alg = std::make_unique<ABS>(5.0, 1, 75);
+    for (auto& _tpx3 : batches) {
+      extractHits(_tpx3, raw_data_ptr, consumed);
+      abs_alg->reset();
+      abs_alg->fit(_tpx3.hits);
+      events.push_back(abs_alg->get_events(_tpx3.hits));
+    }
+  }
+  timer[EVENTS].end = std::chrono::high_resolution_clock::now();
+
+  // report statistics
+  for (const auto& tpx3 : batches) {
+    n_hits += tpx3.hits.size();
+  }
+  // sanity check: hit.getTOF() should be smaller than 666,667 clock, which is
+  //               equivalent to 16.67 ms
+  if ( pulse_rate > 0.0 ) {
+    for (const auto& tpx3 : batches) {
+      for (const auto& hit : tpx3.hits) {
+        auto tof_ms = hit.getTOF_ns() * 1e-6;
+        if (tof_ms > (1.0/pulse_rate)+1e-6) {
+          spdlog::debug("TOF: {} ms", tof_ms);
+          n_bad_hits++;
+        }
+      }
+    }
+  }
+  for (const auto& e : events) {
+    n_events += e.size();
+  }
+
+  // manage iterations on partial raw_data
+  raw_data_consumed += consumed;
+  timer[BATCHES].accumulated += static_cast<double>(std::chrono::duration_cast<std::chrono::microseconds>(timer[BATCHES].end - timer[BATCHES].begin).count());
+  timer[EVENTS].accumulated += static_cast<double>(std::chrono::duration_cast<std::chrono::microseconds>(timer[EVENTS].end - timer[EVENTS].begin).count());
+}
+
+  std::cerr << std::endl;
+
+  timer[TOTAL].end = std::chrono::high_resolution_clock::now();
+  timer[TOTAL].accumulated += static_cast<double>(std::chrono::duration_cast<std::chrono::microseconds>(timer[TOTAL].end - timer[TOTAL].begin).count());
+
+  spdlog::info("Number of hits: {}", n_hits);
+  spdlog::info("Number of events: {}", n_events);
+
+  if (n_hits > 0)
+  {
+    spdlog::info("bad/total hit ratio: {:.2f}%", (n_bad_hits*100.0)/n_hits);
+
+    auto speed_raw_data = n_hits / (timer[RAW_DATA].accumulated / 1e6);
+    auto speed_batches = n_hits / (timer[BATCHES].accumulated / 1e6);
+    auto speed_events = n_hits / (timer[EVENTS].accumulated / 1e6);
+    auto speed_aggregate = n_hits / (timer[TOTAL].accumulated / 1e6);
+    spdlog::info("{:s} speed: {:<e} hits/s", method_raw_data, speed_raw_data);
+    spdlog::info("{:s} speed: {:<e} hits/s", "Batching", speed_batches);
+    spdlog::info("{:s} speed: {:<e} hits/s", method_events, speed_events);
+    spdlog::info("{:s} speed: {:<e} hits/s", "Aggregate", speed_aggregate);
+  }
+
+  // write output
+  // save events to file
+  if( !no_output && n_events > 0 )
+  {
+    spdlog::debug("Writing output: {}", out_dat);
+
+    // NB: events is a vector-of-vectors-of-events that we transfrom into a vector-of-events
+    timer[GATHER].begin = std::chrono::high_resolution_clock::now();
+    std::vector<Neutron> v;
+    for (auto& a : events) {
+      // because Neutron doesn't have a copy constructor
+      for (auto& e : a) {
+        Neutron n(e.getX(), e.getY(), e.getTOF_ns(), e.getTOT(), e.getNHits());
+        v.push_back(n);
+      }
+    }
+    timer[GATHER].end = timer[OUTPUT].begin = std::chrono::high_resolution_clock::now();
+
+    std::string csv_ext = ".csv";
+    std::string bin_ext = ".bin";
+    std::string h5_ext = ".h5";
+
+    if (endsWith(out_dat, csv_ext)) saveEventsToCSV(out_dat, v);
+    else if (endsWith(out_dat, bin_ext)) saveEventsToBIN(out_dat, v);
+    else if (endsWith(out_dat, h5_ext)) saveEventsToHDF5(out_dat, v);
+    else { spdlog::debug("Unhanded extention (.bin, .csv or .h5 are known)"); no_output = true; }
+    timer[OUTPUT].end = std::chrono::high_resolution_clock::now();
+
+    timer[GATHER].accumulated += static_cast<double>(std::chrono::duration_cast<std::chrono::microseconds>(timer[GATHER].end - timer[GATHER].begin).count());
+    timer[OUTPUT].accumulated += static_cast<double>(std::chrono::duration_cast<std::chrono::microseconds>(timer[OUTPUT].end - timer[OUTPUT].begin).count());
+    auto speed_gather = n_events / (timer[GATHER].accumulated / 1e6);
+    auto speed_output = n_events / (timer[OUTPUT].accumulated / 1e6);
+    spdlog::info("{:s} speed: {:<e} events/s", "Gathering Events", speed_gather);
+    if (!no_output) spdlog::info("{:s} speed: {:<e} events/s", "Writing Output", speed_output);
+  }
+}

--- a/sophiread/FastSophiread/include/disk_io.h
+++ b/sophiread/FastSophiread/include/disk_io.h
@@ -33,6 +33,15 @@
 
 std::vector<char> readTPX3RawToCharVec(const std::string& tpx3file);
 
+typedef struct mapinfo {
+    int fd;
+    char *map;
+    size_t max;
+} mapinfo_t;
+
+mapinfo_t readTPX3RawToMapInfo(const std::string& tpx3file);
+mapinfo_t mmapTPX3RawToMapInfo(const std::string& tpx3file);
+
 std::string generateFileNameWithMicroTimestamp(const std::string& originalFileName);
 
 template <typename T, typename ForwardIterator>

--- a/sophiread/FastSophiread/include/tpx3_fast.h
+++ b/sophiread/FastSophiread/include/tpx3_fast.h
@@ -53,10 +53,14 @@ struct TPX3 {
   };
 };
 
-template <typename ForwardIt>
-std::vector<TPX3> findTPX3H(ForwardIt first, ForwardIt last);
+template <typename ForwardIter>
+std::vector<TPX3> findTPX3H(ForwardIter first, ForwardIter last);
 std::vector<TPX3> findTPX3H(const std::vector<char>& raw_bytes);
 std::vector<TPX3> findTPX3H(char* raw_bytes, std::size_t size);
+template <typename ForwardIter>
+std::vector<TPX3> findTPX3H(ForwardIter first, ForwardIter last, std::size_t& consumed);
+std::vector<TPX3> findTPX3H(const std::vector<char>& raw_bytes, std::size_t& consumed);
+std::vector<TPX3> findTPX3H(char* raw_bytes, std::size_t size, std::size_t& consumed);
 
 template <typename ForwardIter>
 void updateTimestamp(TPX3& tpx3h, ForwardIter bytes_begin, ForwardIter bytes_end, unsigned long& tdc_timestamp,

--- a/sophiread/FastSophiread/src/disk_io.cpp
+++ b/sophiread/FastSophiread/src/disk_io.cpp
@@ -59,6 +59,80 @@ std::vector<char> readTPX3RawToCharVec(const std::string& tpx3file) {
 }
 
 /**
+ * @brief Read Timepix3 raw data from file into memory.
+ *
+ * @param tpx3file
+ * @return mapinfo_t that defines { char *, and size_t }
+ */
+mapinfo_t readTPX3RawToMapInfo(const std::string& tpx3file)
+{
+  mapinfo_t info = { -1, NULL, 0 };
+
+  // Open the file
+  std::ifstream file(tpx3file, std::ios::binary | std::ios::ate);
+
+  // Check if file is open successfully
+  if (!file.is_open()) {
+    spdlog::error("Failed to open file: {}", tpx3file);
+    exit(EXIT_FAILURE);
+  }
+
+  // Get the size of the file
+  std::streampos fileSize = file.tellg();
+  file.seekg(0, std::ios::beg);
+  spdlog::info("File size: {} bytes", static_cast<size_t>(fileSize));
+
+  // Allocate a vector to store the data
+  info.max = static_cast<size_t>(fileSize);
+  info.map = reinterpret_cast<char *>(malloc(info.max));
+
+  // Read the data from file and store it in the vector
+  if (info.map == NULL) info.max = 0;
+  else file.read(info.map, info.max);
+
+  // Close the file
+  file.close();
+
+  return info;
+}
+
+// for mmap support
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/mman.h>
+#include <errno.h>
+#include <unistd.h>
+
+/**
+ * @brief Memory-map a Timepix3 raw data file (without pre-reading it).
+ *
+ * @param tpx3file
+ * @return mapinfo_t that defines { char *, and size_t }
+ */
+mapinfo_t mmapTPX3RawToMapInfo(const std::string& tpx3file)
+{
+  mapinfo_t info = { -1, NULL, 0 };
+
+  std::ifstream file(tpx3file, std::ios::binary);
+  if (!file.is_open()) {
+    spdlog::error("Failed to open file: {}", tpx3file);
+    exit(EXIT_FAILURE);
+  }
+
+  info.fd = open(tpx3file.c_str(),O_RDWR,0666);
+
+  if( info.fd == -1 ) { perror(tpx3file.c_str()); exit(EXIT_FAILURE); }
+  info.max = lseek(info.fd,0,SEEK_END);     // determine the sizeof the file
+  info.map = reinterpret_cast<char *>(mmap(0, info.max, PROT_READ|PROT_WRITE, MAP_SHARED, info.fd, 0));
+  // https://lemire.me/blog/2012/06/26/which-is-fastest-read-fread-ifstream-or-mmap/
+  // says to add MAP_POPULATE to make it mmap() faster...
+  // TODO: Test this
+
+  return info;
+  // https://stackoverflow.com/questions/26569217/do-i-have-to-munmap-a-mmap-file ( consensus is that you do not need to do it )
+}
+
+/**
  * @brief Append microsecond timestamp to the file name.
  *
  * @param[in] originalFileName

--- a/sophiread/FastSophiread/src/tpx3_fast.cpp
+++ b/sophiread/FastSophiread/src/tpx3_fast.cpp
@@ -25,6 +25,19 @@
 #include <iostream>
 #include <numeric>
 
+#define MAX_BATCH_LEN	100000 // enough to process suann_socket_background_serval32.tpx3 without rollover
+#ifdef MAX_BATCH_LEN
+#include <cstdlib>
+std::size_t _get_max_batch_len(void) {
+    if (const char* env_p = std::getenv("MAX_BATCH_LEN")) {
+        auto max_batch_len = std::strtoull(env_p, (void *)0, 0);
+        // no conversion or range error produce 0 or UULONG_MAX respectively
+        if (max_batch_len != 0 && max_batch_len != std::UULONG_MAX )
+            return (std::size_t)max_batch_len;
+    }
+    return (std::size_t)MAX_BATCH_LEN;
+}
+
 /**
  * @brief Templated function to locate all TPX3H (chip dataset) in the raw data.
  *
@@ -61,6 +74,54 @@ std::vector<TPX3> findTPX3H(ForwardIter begin, ForwardIter end) {
 }
 
 /**
+ * @brief Templated function to locate all TPX3H (chip dataset) in the raw data.
+ *
+ * @tparam ForwardIter
+ * @param[in] begin
+ * @param[in] end
+ * @param[out] consumed
+ * @return std::vector<TPX3>
+ * @note will limit the batch size to 100000, will update the number of elements consumed
+ */
+template <typename ForwardIter>
+std::vector<TPX3> findTPX3H(ForwardIter begin, ForwardIter end, std::size_t &consumed) {
+  std::vector<TPX3> batches;
+  auto len = std::distance(begin, end) / 64;
+#ifdef MAX_BATCH_LEN
+  if ( len > MAX_BATCH_LEN ) {
+    len = MAX_BATCH_LEN;
+  }
+#endif  // MAX_BATCH_LEN
+  batches.reserve(len);
+  consumed = 0;
+
+  // local variables
+  int chip_layout_type = 0;
+  int data_packet_size = 0;
+  int data_packet_num = 0;
+
+  // find all batches
+  for (auto iter = begin; std::distance(iter, end) >= 8; std::advance(iter, 8), consumed += 8) {
+    const char *char_array = &(*iter);
+#ifdef MAX_BATCH_LEN
+    if (batches.size() >= MAX_BATCH_LEN) {
+      break;
+    }
+#endif  // MAX_BATCH_LEN
+
+    // locate the data packet header
+    if (char_array[0] == 'T' && char_array[1] == 'P' && char_array[2] == 'X') {
+      data_packet_size = ((0xff & char_array[7]) << 8) | (0xff & char_array[6]);
+      data_packet_num = data_packet_size >> 3;  // every 8 (2^3) bytes is a data packet
+      chip_layout_type = static_cast<int>(char_array[4]);
+      batches.emplace_back(static_cast<size_t>(std::distance(begin, iter)), data_packet_num, chip_layout_type);
+    }
+  }
+
+  return batches;
+}
+
+/**
  * @brief Locate all TPX3H (chip dataset) in the raw data.
  *
  * @param[in] raw_bytes
@@ -73,11 +134,36 @@ std::vector<TPX3> findTPX3H(const std::vector<char> &raw_bytes) {
 /**
  * @brief Locate all TPX3H (chip dataset) in the raw data.
  *
- * @param raw_bytes
- * @param size
+ * @param[in] raw_bytes
+ * @param[in] size
  * @return std::vector<TPX3>
  */
-std::vector<TPX3> findTPX3H(char *raw_bytes, std::size_t size) { return findTPX3H(raw_bytes, raw_bytes + size); }
+std::vector<TPX3> findTPX3H(char *raw_bytes, std::size_t size) {
+  return findTPX3H(raw_bytes, raw_bytes + size);
+}
+
+/**
+ * @brief Locate all TPX3H (chip dataset) in the raw data.
+ *
+ * @param[in] raw_bytes
+ * @param[out] consumed
+ * @return std::vector<TPX3H>
+ */
+std::vector<TPX3> findTPX3H(const std::vector<char> &raw_bytes, std::size_t& consumed) {
+  return findTPX3H(raw_bytes.cbegin(), raw_bytes.cend(), consumed);
+}
+
+/**
+ * @brief Locate all TPX3H (chip dataset) in the raw data.
+ *
+ * @param[in] raw_bytes
+ * @param[in] size
+ * @param[out] consumed
+ * @return std::vector<TPX3>
+ */
+std::vector<TPX3> findTPX3H(char *raw_bytes, std::size_t size, std::size_t& consumed) {
+  return findTPX3H(raw_bytes, raw_bytes + size, consumed);
+}
 
 /**
  * @brief record the given timestamp as starting timestamp of the dataset batch, and evolve the timestamp till the end

--- a/sophiread/FastSophiread/tests/test_disk_io.cpp
+++ b/sophiread/FastSophiread/tests/test_disk_io.cpp
@@ -53,6 +53,24 @@ TEST(DiskIOTest, ReadTPX3RawToCharVec) {
   EXPECT_EQ(rawdata.size(), ref_size);
 }
 
+TEST(DiskIOTest, ReadTPX3RawToMapInfo) {
+  // read the testing raw data, same interface as memory map
+  auto raw = readTPX3RawToMapInfo("../data/frames_flood_1M.tpx3");
+
+  // check the size of the raw data
+  const unsigned long ref_size = 9739597 * 8;
+  EXPECT_EQ(raw.max, ref_size);
+}
+
+TEST(DiskIOTest, MmapTPX3RawToMapInfo) {
+  // memory map the testing raw data
+  auto raw = mmapTPX3RawToMapInfo("../data/frames_flood_1M.tpx3");
+
+  // check the size of the raw data
+  const unsigned long ref_size = 9739597 * 8;
+  EXPECT_EQ(raw.max, ref_size);
+}
+
 class FileNameGeneratorTest : public ::testing::Test {
  protected:
   std::regex expectedPattern;

--- a/sophiread/FastSophiread/tests/test_tpx3.cpp
+++ b/sophiread/FastSophiread/tests/test_tpx3.cpp
@@ -80,6 +80,30 @@ TEST(TPX3FuncTest, TestFindTPX3H) {
   EXPECT_EQ(batches.size(), size_reference);
 }
 
+TEST(TPX3FuncTest, TestFindTPX3H_read) {
+  // read the testing raw data
+  auto mapdata = readTPX3RawToMapInfo("../data/suann_socket_background_serval32.tpx3");
+
+  //
+  auto batches = findTPX3H(mapdata.map, mapdata.max);
+
+  // check the size of the raw data
+  const size_t size_reference = 81399;
+  EXPECT_EQ(batches.size(), size_reference);
+}
+
+TEST(TPX3FuncTest, TestFindTPX3H_mmap) {
+  // memory map the testing raw data
+  auto mapdata = mmapTPX3RawToMapInfo("../data/suann_socket_background_serval32.tpx3");
+
+  //
+  auto batches = findTPX3H(mapdata.map, mapdata.max);
+
+  // check the size of the raw data
+  const size_t size_reference = 81399;
+  EXPECT_EQ(batches.size(), size_reference);
+}
+
 TEST(TPX3FuncTest, TestExtractHits) {
   // read the testing raw data
   auto rawdata = readTPX3RawToCharVec("../data/suann_socket_background_serval32.tpx3");
@@ -117,6 +141,139 @@ TEST(TPX3FuncTest, TestExtractHits) {
       EXPECT_LT(tof_ms, 16670);
     }
   }
+}
+
+TEST(TPX3FuncTest, TestExtractHits_read) {
+  // read the testing raw data
+  auto mapdata = readTPX3RawToMapInfo("../data/suann_socket_background_serval32.tpx3");
+
+  // locate all headers
+  auto batches = findTPX3H(mapdata.map, mapdata.max);
+
+  // locate gdc and tdc
+  unsigned long tdc_timestamp = 0;
+  unsigned long long int gdc_timestamp = 0;
+  unsigned long timer_lsb32 = 0;
+  for (auto& tpx3 : batches) {
+    updateTimestamp(tpx3, mapdata.map, mapdata.max, tdc_timestamp, gdc_timestamp, timer_lsb32);
+  }
+
+  // extract hits
+  for (auto& tpx3 : batches) {
+    extractHits(tpx3, mapdata.map, mapdata.max);
+  }
+
+  //
+  int n_hits = 0;
+  for (const auto& tpx3 : batches) {
+    auto hits = tpx3.hits;
+    n_hits += hits.size();
+  }
+  const int n_hits_reference = 98533;
+  EXPECT_EQ(n_hits, n_hits_reference);
+
+  // make sure no tof is above 16.67 ms
+  for (const auto& tpx3 : batches) {
+    auto hits = tpx3.hits;
+    for (const auto& hit : hits) {
+      auto tof_ms = hit.getTOF_ns() * 1e-6;
+      EXPECT_LT(tof_ms, 16670);
+    }
+  }
+}
+
+TEST(TPX3FuncTest, TestExtractHits_mmap) {
+  // memory map the testing raw data
+  auto mapdata = mmapTPX3RawToMapInfo("../data/suann_socket_background_serval32.tpx3");
+
+  // locate all headers
+  auto batches = findTPX3H(mapdata.map, mapdata.max);
+
+  // locate gdc and tdc
+  unsigned long tdc_timestamp = 0;
+  unsigned long long int gdc_timestamp = 0;
+  unsigned long timer_lsb32 = 0;
+  for (auto& tpx3 : batches) {
+    updateTimestamp(tpx3, mapdata.map, mapdata.max, tdc_timestamp, gdc_timestamp, timer_lsb32);
+  }
+
+  // extract hits
+  for (auto& tpx3 : batches) {
+    extractHits(tpx3, mapdata.map, mapdata.max);
+  }
+
+  //
+  int n_hits = 0;
+  for (const auto& tpx3 : batches) {
+    auto hits = tpx3.hits;
+    n_hits += hits.size();
+  }
+  const int n_hits_reference = 98533;
+  EXPECT_EQ(n_hits, n_hits_reference);
+
+  // make sure no tof is above 16.67 ms
+  for (const auto& tpx3 : batches) {
+    auto hits = tpx3.hits;
+    for (const auto& hit : hits) {
+      auto tof_ms = hit.getTOF_ns() * 1e-6;
+      EXPECT_LT(tof_ms, 16670);
+    }
+  }
+}
+
+TEST(TPX3FuncTest, TestExtractHits_large) {
+  // memory map the testing raw data
+  auto mapdata = mmapTPX3RawToMapInfo("../data/HV2700_1500_500_THLrel_274_sophy_chopper_60Hz_4.1mm_aperture_siemen_star_120s_000000.tpx3");
+  //auto mapdata = mmapTPX3RawToMapInfo("../data/suann_socket_background_serval32.tpx3");
+  size_t raw_data_consumed = 0;
+  size_t n_hits = 0;
+
+ while (raw_data_consumed < mapdata.max) {
+
+  // manage partial batches
+  size_t consumed = 0;
+  char *raw_data_ptr = mapdata.map + raw_data_consumed;
+  size_t raw_data_size = mapdata.max - raw_data_consumed;
+
+  // locate all headers
+  auto batches = findTPX3H(raw_data_ptr, raw_data_size, consumed);
+
+  // locate gdc and tdc
+  unsigned long tdc_timestamp = 0;
+  unsigned long long int gdc_timestamp = 0;
+  unsigned long timer_lsb32 = 0;
+  for (auto& tpx3 : batches) {
+    updateTimestamp(tpx3, raw_data_ptr, consumed, tdc_timestamp, gdc_timestamp, timer_lsb32);
+  }
+
+  // extract hits
+  for (auto& tpx3 : batches) {
+    extractHits(tpx3, raw_data_ptr, consumed);
+  }
+
+  // count all hits
+  for (const auto& tpx3 : batches) {
+    auto hits = tpx3.hits;
+    n_hits += hits.size();
+  }
+
+  // make sure no tof is above 16.67 ms
+  for (const auto& tpx3 : batches) {
+    auto hits = tpx3.hits;
+    for (const auto& hit : hits) {
+      auto tof_ms = hit.getTOF_ns() * 1e-6;
+      EXPECT_LT(tof_ms, 16670);
+    }
+  }
+
+  // manage iterations on partial raw_data
+  raw_data_consumed += consumed;
+ }
+
+  const int n_hits_reference = 5199514+80927; // HV2700_1500_500_THLrel_274_sophy_chopper_60Hz_4.1mm_aperture_siemen_star_120s_000000.tpx3
+  //const int n_hits_reference = 98533;       // suann_socket_background_serval32.tpx3
+  EXPECT_EQ(n_hits, n_hits_reference);
+
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
# Description of Pull Request

This PR implements the code necessary to operate over memory regions and to facilitate streaming operations.

## Purpose/Summary of work
As per #51, adjustments to the `findTPX3H()` API are made to implement the 3 requirements.  Test cases are added to verify that use of `mmap()` and memory spaces are equivalent to the `std::vector<char *>` of the current implementation.  A new CLI program `benchmark_mmap.cpp` is provided to process both single-thread and tbb use cases in a looping mode that is conducive for streaming processing.

## Additional detail of work
Per discussions with@KedoKudo, I'm providing this PR with the `benchmark_mmap.cpp` as the reference implementation.  The canonical CLI program `sophiread.cpp` could be  extended with memory mapped support, but I gratefully appreciate this PR to be considered using the above reference.  I do apologize that `benchmark_mmap.cpp` duplicates some of the functions in the common library and I am willing to offer additional PRs to resolve these, if needed.

The environment variable `MAX_BATCH_LEN` is used to control the amount of intermediate data structures that are allocated during processing.  The test programs are sensitive to this value as the number of events produced can vary.  This is because partial events are not yet handled gracefully as batches are iterated upon.  This is a known limitation at this time.  The test programs have been calibrated with a `MAX_BATCH_LEN=100000`, as this was known to prevent batching when processing the data set `data/suann_socket_background_serval32.tpx3`.  However, the data set `data/HV2700_1500_500_THLrel_274_sophy_chopper_60Hz_4.1mm_aperture_siemen_star_120s_000000.tpx3` which is used in the performance benchmark, does roll-over at this setting ( *it appears as if a length of 1000000 may be needed to prevent roll-over there* ).  This implementation has parsed the `MAX_BATCH_LEN` from the environment in `sophiread/FastSophiread/src/tpx3_fast.cpp`.  It is not critical that this restriction be imposed, but lack of it will prevent extremely large `.tpx3` files from being successfully processed.

## Testing instructions

Test using standard build instructions, and operations.  To observe the use of mmap(), use `FastSophireadBenchmarksCLI.app` and provide the `mmap` string as options.  For example:

```
./FastSophireadBenchmarksCLI.app data/HV2700_1500_500_THLrel_274_sophy_chopper_60Hz_4.1mm_aperture_siemen_star_120s_000000.tpx3 /tmp/foo.h5 tgdc+mmap
```

A suite of test cases and benchmarks comparing the operation of single/tbb/streaming/mmap can be executed via `FastSophiread_benchmark.sh`.  As demonstrated by:

```
conda activate sophiread
mkdir sophiread/build && cd sophiread/build
cmake ..
make -j4
make test
./FastSophiread_benchmark.sh
```

[mcpevent2hist-pr-mmap-test-output.txt](https://github.com/ornlneutronimaging/mcpevent2hist/files/14104871/mcpevent2hist-pr-mmap-test-output.txt)
