### PR TITLE
Fix improper loop exit with MAX_BATCH_LEN and fix the test case for it

### DIFF
--- a/sophiread/FastSophiread/tests/test_tpx3.cpp
+++ b/sophiread/FastSophiread/tests/test_tpx3.cpp
@@ -224,9 +224,15 @@ TEST(TPX3FuncTest, TestExtractHits_mmap) {
 TEST(TPX3FuncTest, TestExtractHits_large) {
   // memory map the testing raw data
   auto mapdata = mmapTPX3RawToMapInfo("../data/HV2700_1500_500_THLrel_274_sophy_chopper_60Hz_4.1mm_aperture_siemen_star_120s_000000.tpx3");
+  const int n_hits_reference = 5303344;       // HV2700_1500_500_THLrel_274_sophy_chopper_60Hz_4.1mm_aperture_siemen_star_120s_000000.tpx3
   //auto mapdata = mmapTPX3RawToMapInfo("../data/suann_socket_background_serval32.tpx3");
+  //const int n_hits_reference = 98533;       // suann_socket_background_serval32.tpx3
   size_t raw_data_consumed = 0;
   size_t n_hits = 0;
+  // NB: these track timestamps; if they are reset improperly, the system keeps searching and gets the wrong answers!
+  unsigned long tdc_timestamp = 0;
+  unsigned long long int gdc_timestamp = 0;
+  unsigned long timer_lsb32 = 0;
 
  while (raw_data_consumed < mapdata.max) {
 
@@ -239,9 +245,6 @@ TEST(TPX3FuncTest, TestExtractHits_large) {
   auto batches = findTPX3H(raw_data_ptr, raw_data_size, consumed);
 
   // locate gdc and tdc
-  unsigned long tdc_timestamp = 0;
-  unsigned long long int gdc_timestamp = 0;
-  unsigned long timer_lsb32 = 0;
   for (auto& tpx3 : batches) {
     updateTimestamp(tpx3, raw_data_ptr, consumed, tdc_timestamp, gdc_timestamp, timer_lsb32);
   }
@@ -270,8 +273,6 @@ TEST(TPX3FuncTest, TestExtractHits_large) {
   raw_data_consumed += consumed;
  }
 
-  const int n_hits_reference = 5199514+80927; // HV2700_1500_500_THLrel_274_sophy_chopper_60Hz_4.1mm_aperture_siemen_star_120s_000000.tpx3
-  //const int n_hits_reference = 98533;       // suann_socket_background_serval32.tpx3
   EXPECT_EQ(n_hits, n_hits_reference);
 
 }


### PR DESCRIPTION
# Description of Pull Request

This pull request resolves a bug introduced with `MAX_BATCH_LEN` processing in `tpx3_fast.cpp`.

## Purpose of work

In #51, it was remarked that bounding the batch size was necessary when operating in very large `.tpx3` files on disk.  Otherwise, the algorithm could allocate too much processing memory and fail.  PR #52, provided an implementation.

When performing tests that varied `MAX_BATCH_LEN`, the test which used `mmapTPX3RawToMapInfo()` on a file large enough to trigger the partial processing would return different numbers of hits depending on the batch length chosen.

[pr-52-test-fail.txt](https://github.com/ornlneutronimaging/mcpevent2hist/files/14187991/pr-52-test-fail.txt)

## Summary of work

This PR resolves the problem with the test case not using the correct hit number reference.  It also fixes the bug in `findTPX3H(iter, iter, std::size_t &)` that dropped batches on an early exit due to the `MAX_BATCH_LEN` restriction.

## Testing instructions

Build normally, then:
```
MAX_BATCH_LEN=100 make test
MAX_BATCH_LEN=1000 make test
MAX_BATCH_LEN=10000 make test
MAX_BATCH_LEN=100000 make test
MAX_BATCH_LEN=1000000 make test
```
Should all pass.  Prior to this PR, this would fail on test 25/34 due to a expected hit count mismatch.

You may also stress test:
```
for m in $(seq 100 100 110000) ; do echo "$m" && if ! ( MAX_BATCH_LEN=${m} make test ) > /tmp/test.log ; then break; fi ; done
```
