### PR TITLE
[QoL] Add CMake package config

### DIFF
--- a/sophiread/CMakeLists.txt
+++ b/sophiread/CMakeLists.txt
@@ -87,6 +87,13 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/sophireadConfig.cmake
               ${CMAKE_CURRENT_BINARY_DIR}/sophireadConfigVersion.cmake
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/sophiread)
 
+# For package config
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/sophiread.pc.in
+               ${CMAKE_CURRENT_BINARY_DIR}/sophiread.pc @ONLY)
+
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/sophiread.pc
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+
 # ----------------- DOXYGEN ----------------- #
 find_package(Doxygen)
 if(DOXYGEN_FOUND)

--- a/sophiread/CMakeLists.txt
+++ b/sophiread/CMakeLists.txt
@@ -23,8 +23,12 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
 
+include(GNUInstallDirs)
+
 set(CMAKE_CXX_STANDARD 20)
-# set(CMAKE_AUTOMOC ON)  # for meta object compiler, needed for Qt5
+set(CMAKE_INSTALL_RPATH "$ORIGIN/../lib")
+set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 # Dependencies
 find_package(Eigen3 REQUIRED)
@@ -35,7 +39,6 @@ find_package(TBB REQUIRED)
 find_package(TIFF REQUIRED)
 find_package(spdlog 1.8.0 REQUIRED)
 find_package(fmt 7.0.0 REQUIRED)
-# find_package(Qt5 COMPONENTS Widgets REQUIRED)
 
 # Testing setup
 enable_testing()
@@ -54,19 +57,35 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
   add_compile_options(-march=native -ffast-math -pthread -Wall -Wextra)
 endif()
 
-# Add Sophiread library NOTE: this will take care of the testing as well
-# add_subdirectory(SophireadLib)
-
 # Add FastSophiread library
 add_subdirectory(FastSophiread)
-
-# Add Sophiread command line interface
 add_subdirectory(SophireadCLI)
 
-# Add Sophiread stream command line interface
-# add_subdirectory(SophireadStreamCLI)
+# ----------------- PACKAGE CONFIGURATION ----------------- #
 
-# Add Sophiread GUI application add_subdirectory(SophireadGUI)
+# Export targets from subdirectories
+install(
+  EXPORT sophireadTargets
+  FILE sophireadTargets.cmake
+  NAMESPACE sophiread::
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/sophiread)
+
+# Generate and install the sophireadConfig.cmake and
+# sophireadConfigVersion.cmake files
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+  ${CMAKE_CURRENT_BINARY_DIR}/sophireadConfigVersion.cmake
+  VERSION ${PROJECT_VERSION}
+  COMPATIBILITY AnyNewerVersion)
+
+configure_package_config_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/sophireadConfig.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/sophireadConfig.cmake
+  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/sophiread)
+
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/sophireadConfig.cmake
+              ${CMAKE_CURRENT_BINARY_DIR}/sophireadConfigVersion.cmake
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/sophiread)
 
 # ----------------- DOXYGEN ----------------- #
 find_package(Doxygen)

--- a/sophiread/FastSophiread/CMakeLists.txt
+++ b/sophiread/FastSophiread/CMakeLists.txt
@@ -6,9 +6,24 @@ set(SRC_FAST_FILES src/abs.cpp src/centroid.cpp src/disk_io.cpp
 add_library(FastSophiread ${SRC_FAST_FILES})
 target_include_directories(
   FastSophiread
-  PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include $ENV{CONDA_PREFIX}/include
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+         $<INSTALL_INTERFACE:include> $ENV{CONDA_PREFIX}/include
          ${EIGEN3_INCLUDE_DIR} ${HDF5_INCLUDE_DIRS})
 target_link_directories(FastSophiread PRIVATE $ENV{CONDA_PREFIX}/lib)
+
+# Install the library
+install(
+  TARGETS FastSophiread
+  EXPORT sophireadTargets
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  INCLUDES
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+# Install the headers
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 # ----------------- TESTS ----------------- #
 function(add_sophiread_test test_name)

--- a/sophiread/SophireadCLI/CMakeLists.txt
+++ b/sophiread/SophireadCLI/CMakeLists.txt
@@ -81,6 +81,17 @@ if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
       "/usr/local"
       CACHE PATH "Default install prefix" FORCE)
 endif()
-install(TARGETS Sophiread RUNTIME DESTINATION bin)
+
+# Install executables
+install(
+  TARGETS Sophiread venus_auto_reducer
+  EXPORT sophireadTargets
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+# Install the headers
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+# Set up packaging (optional)
 set(CPACK_RESOURCE_FILE_LICENSE "${PROJECT_SOURCE_DIR}/LICENSE")
 include(CPack)

--- a/sophiread/cmake/sophireadConfig.cmake.in
+++ b/sophiread/cmake/sophireadConfig.cmake.in
@@ -1,0 +1,7 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/sophireadTargets.cmake")
+
+# Optionally, include additional paths or variables
+set(SOPHIREAD_INCLUDE_DIRS "@CMAKE_INSTALL_FULL_INCLUDEDIR@")
+set(SOPHIREAD_LIBRARIES sophiread::FastSophiread)

--- a/sophiread/include/version.h
+++ b/sophiread/include/version.h
@@ -1,6 +1,6 @@
 /**version.h
  *
- * Copyright 2023.
+ * Copyright 2024.
  */
 
 #ifndef VERSION_H
@@ -12,7 +12,7 @@
 
 // Version number
 #define VERSION_MAJOR 2
-#define VERSION_MINOR 0
+#define VERSION_MINOR 3
 #define VERSION_PATCH 0
 
 // Version number final

--- a/sophiread/sophiread.pc.in
+++ b/sophiread/sophiread.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: Sophiread
+Description: A library for processing TPX3 raw data
+Version: @PROJECT_VERSION@
+Cflags: -I${includedir}
+Libs: -L${libdir} -lFastSophiread


### PR DESCRIPTION
# Description of Pull Request

This PR introduces the following changes:

- add CMake target to generate package config file for other program to use.
- add `pkg-config` target to generate file used by `pkg-config`

## Purpose of work
<!--
Why has this work been done?
If there is no linked issue please provide appropriate context for this work.
-->

The purpose of this work is to make using `sophiread` library easier for developers.

<!-- If the original issue was raised by a user they should be named here.
NOTE: you can use @GITHUB_USERNAME to reference a user.
-->

## Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
N/A

## Additional detail of work
<!-- [Optional] If there is additional detail that is relevant to this PR, please provide it here.
-->
N/A

## Testing instructions

- Check out the branch
- Build the branch with `cmake -DCMAKE_INSTALL_PREFIX=../install ..`
- Run `cmake --build . --target install`
- Go to `../install` to verify that `Sophiread` and `venus_auto_reducer` are in `bin`, headers are in `include`, and libraries and cmake files are in `lib`.
- [Mac only] install `pkg-config` with `brew install pkg-config`
- Run `export PKG_CONFIG_PATH=../install/lib/pkgconfig:$PKG_CONFIG_PATH`
- Check `pkg-config --cflags --libs sophiread`

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

Fixes #61 
<!-- and fix #xxxx or close #xxxx xor resolves #xxxx
NOTE: skip this part if not applicable to your PR.
-->
