### PR TITLE
Enable chunk processing

### DIFF
--- a/sophiread/FastSophiread/include/disk_io.h
+++ b/sophiread/FastSophiread/include/disk_io.h
@@ -103,3 +103,17 @@ private:
     size_t fileSize;
     size_t currentPosition;
 };
+
+// directly working with HDF5 handles
+void appendHitsToHDF5(H5::H5File& file, const std::vector<Hit>& hits);
+void appendNeutronsToHDF5(H5::H5File& file, const std::vector<Neutron>& neutrons);
+// Helper function for appending data to HDF5
+template <typename T, typename ForwardIterator>
+void appendToHDF5(
+    H5::H5File& out_file,
+    ForwardIterator data_begin,
+    ForwardIterator data_end,
+    const std::string& baseGroupName,
+    const std::vector
+        std::pair<std::string, std::function<T(const decltype(*data_begin)&)>>>
+        & attributes);

--- a/sophiread/FastSophiread/include/disk_io.h
+++ b/sophiread/FastSophiread/include/disk_io.h
@@ -104,7 +104,7 @@ class TPX3FileReader {
   size_t currentPosition;
 };
 
-//
+// Helper functions to append data to extendible datasets
 void createOrExtendDataset(H5::Group& group, const std::string& datasetName,
                            const std::vector<double>& data);
 void appendHitsToHDF5Extendible(H5::H5File& file, const std::vector<Hit>& hits);

--- a/sophiread/FastSophiread/include/disk_io.h
+++ b/sophiread/FastSophiread/include/disk_io.h
@@ -11,16 +11,16 @@
 #pragma once
 
 #include <H5Cpp.h>
-
-#include <fstream>
-#include <functional>
-#include <iostream>
-#include <vector>
 #include <errno.h>
 #include <fcntl.h>
 #include <sys/mman.h>
 #include <sys/types.h>
 #include <unistd.h>
+
+#include <fstream>
+#include <functional>
+#include <iostream>
+#include <vector>
 
 #include "hit.h"
 #include "neutron.h"
@@ -89,23 +89,24 @@ void appendNeutronToHDF5(const std::string& out_file_name,
                          const std::vector<Neutron>& neutrons);
 
 class TPX3FileReader {
-public:
-    TPX3FileReader(const std::string& filename);
-    ~TPX3FileReader();
+ public:
+  TPX3FileReader(const std::string& filename);
+  ~TPX3FileReader();
 
-    std::vector<char> readChunk(size_t chunkSize);
-    bool isEOF() const { return currentPosition >= fileSize; }
-    size_t getTotalSize() const { return fileSize; }
+  std::vector<char> readChunk(size_t chunkSize);
+  bool isEOF() const { return currentPosition >= fileSize; }
+  size_t getTotalSize() const { return fileSize; }
 
-private:
-    int fd;
-    char* map;
-    size_t fileSize;
-    size_t currentPosition;
+ private:
+  int fd;
+  char* map;
+  size_t fileSize;
+  size_t currentPosition;
 };
 
 //
-void createOrExtendDataset(H5::Group& group, const std::string& datasetName, 
+void createOrExtendDataset(H5::Group& group, const std::string& datasetName,
                            const std::vector<double>& data);
 void appendHitsToHDF5Extendible(H5::H5File& file, const std::vector<Hit>& hits);
-void appendNeutronsToHDF5Extendible(H5::H5File& file, const std::vector<Neutron>& neutrons);
+void appendNeutronsToHDF5Extendible(H5::H5File& file,
+                                    const std::vector<Neutron>& neutrons);

--- a/sophiread/FastSophiread/include/disk_io.h
+++ b/sophiread/FastSophiread/include/disk_io.h
@@ -104,16 +104,8 @@ private:
     size_t currentPosition;
 };
 
-// directly working with HDF5 handles
-void appendHitsToHDF5(H5::H5File& file, const std::vector<Hit>& hits);
-void appendNeutronsToHDF5(H5::H5File& file, const std::vector<Neutron>& neutrons);
-// Helper function for appending data to HDF5
-template <typename T, typename ForwardIterator>
-void appendToHDF5(
-    H5::H5File& out_file,
-    ForwardIterator data_begin,
-    ForwardIterator data_end,
-    const std::string& baseGroupName,
-    const std::vector
-        std::pair<std::string, std::function<T(const decltype(*data_begin)&)>>>
-        & attributes);
+//
+void createOrExtendDataset(H5::Group& group, const std::string& datasetName, 
+                           const std::vector<double>& data);
+void appendHitsToHDF5Extendible(H5::H5File& file, const std::vector<Hit>& hits);
+void appendNeutronsToHDF5Extendible(H5::H5File& file, const std::vector<Neutron>& neutrons);

--- a/sophiread/FastSophiread/include/disk_io.h
+++ b/sophiread/FastSophiread/include/disk_io.h
@@ -16,6 +16,11 @@
 #include <functional>
 #include <iostream>
 #include <vector>
+#include <errno.h>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/types.h>
+#include <unistd.h>
 
 #include "hit.h"
 #include "neutron.h"
@@ -82,3 +87,19 @@ void appendNeutronToHDF5(const std::string& out_file_name,
                          ForwardIterator neutron_end);
 void appendNeutronToHDF5(const std::string& out_file_name,
                          const std::vector<Neutron>& neutrons);
+
+class TPX3FileReader {
+public:
+    TPX3FileReader(const std::string& filename);
+    ~TPX3FileReader();
+
+    std::vector<char> readChunk(size_t chunkSize);
+    bool isEOF() const { return currentPosition >= fileSize; }
+    size_t getTotalSize() const { return fileSize; }
+
+private:
+    int fd;
+    char* map;
+    size_t fileSize;
+    size_t currentPosition;
+};

--- a/sophiread/FastSophiread/src/disk_io.cpp
+++ b/sophiread/FastSophiread/src/disk_io.cpp
@@ -429,6 +429,11 @@ void appendNeutronToHDF5(const std::string &out_file_name,
   appendNeutronToHDF5(out_file_name, neutrons.cbegin(), neutrons.cend());
 }
 
+/**
+ * @brief Construct a new TPX3FileReader::TPX3FileReader object
+ *
+ * @param[in] filename
+ */
 TPX3FileReader::TPX3FileReader(const std::string &filename) {
   fd = open(filename.c_str(), O_RDONLY);
   if (fd == -1) {
@@ -456,6 +461,9 @@ TPX3FileReader::TPX3FileReader(const std::string &filename) {
   spdlog::info("Opened file: {}, size: {} bytes", filename, fileSize);
 }
 
+/**
+ * @brief Destroy the TPX3FileReader::TPX3FileReader object
+ */
 TPX3FileReader::~TPX3FileReader() {
   if (map != MAP_FAILED) {
     munmap(map, fileSize);
@@ -465,6 +473,11 @@ TPX3FileReader::~TPX3FileReader() {
   }
 }
 
+/**
+ * @brief Read a chunk of data from the file.
+ *
+ * @param[in] chunkSize: size of the chunk to read
+ */
 std::vector<char> TPX3FileReader::readChunk(size_t chunkSize) {
   if (currentPosition >= fileSize) {
     return std::vector<char>();  // Return empty vector if we've reached the end
@@ -483,6 +496,13 @@ std::vector<char> TPX3FileReader::readChunk(size_t chunkSize) {
   return chunk;
 }
 
+/**
+ * @brief Create or extend a dataset in a HDF5 group.
+ *
+ * @param[in] group: HDF5 group
+ * @param[in] datasetName: name of the dataset
+ * @param[in] data: data to write to the dataset
+ */
 void createOrExtendDataset(H5::Group &group, const std::string &datasetName,
                            const std::vector<double> &data) {
   spdlog::debug("Creating or extending dataset '{}' with {} elements",
@@ -546,6 +566,12 @@ void createOrExtendDataset(H5::Group &group, const std::string &datasetName,
   }
 }
 
+/**
+ * @brief Append hits to an extendible HDF5 file.
+ *
+ * @param[in] file: HDF5 file
+ * @param[in] hits: vector of hits to append
+ */
 void appendHitsToHDF5Extendible(H5::H5File &file,
                                 const std::vector<Hit> &hits) {
   if (hits.empty()) {
@@ -597,6 +623,12 @@ void appendHitsToHDF5Extendible(H5::H5File &file,
   group.close();
 }
 
+/**
+ * @brief Append neutrons to an extendible HDF5 file.
+ *
+ * @param[in] file: HDF5 file
+ * @param[in] neutrons: vector of neutrons to append
+ */
 void appendNeutronsToHDF5Extendible(H5::H5File &file,
                                     const std::vector<Neutron> &neutrons) {
   if (neutrons.empty()) {

--- a/sophiread/SophireadCLI/include/sophiread_core.h
+++ b/sophiread/SophireadCLI/include/sophiread_core.h
@@ -22,7 +22,10 @@ namespace sophiread {
 std::vector<char> timedReadDataToCharVec(const std::string& in_tpx3);
 std::vector<TPX3> timedFindTPX3H(const std::vector<char>& rawdata);
 void timedLocateTimeStamp(std::vector<TPX3>& batches,
-                          const std::vector<char>& rawdata);
+                          const std::vector<char>& chunk,
+                          unsigned long& tdc_timestamp,
+                          unsigned long long& gdc_timestamp,
+                          unsigned long& timer_lsb32);
 void timedProcessing(std::vector<TPX3>& batches,
                      const std::vector<char>& raw_data, const IConfig& config);
 void timedSaveHitsToHDF5(const std::string& out_hits,
@@ -37,6 +40,8 @@ void timedSaveTOFImagingToTIFF(
     const std::vector<std::vector<std::vector<unsigned int>>>& tof_images,
     const std::vector<double>& tof_bin_edges,
     const std::string& tof_filename_base);
+std::vector<std::vector<std::vector<unsigned int>>> initializeTOFImages(
+    double super_resolution, const std::vector<double>& tof_bin_edges);
 void updateTOFImages(
     std::vector<std::vector<std::vector<unsigned int>>>& tof_images,
     const TPX3& batch, double super_resolution,

--- a/sophiread/SophireadCLI/include/sophiread_core.h
+++ b/sophiread/SophireadCLI/include/sophiread_core.h
@@ -37,4 +37,8 @@ void timedSaveTOFImagingToTIFF(
     const std::vector<std::vector<std::vector<unsigned int>>>& tof_images,
     const std::vector<double>& tof_bin_edges,
     const std::string& tof_filename_base);
+void updateTOFImages(
+    std::vector<std::vector<std::vector<unsigned int>>>& tof_images,
+    const TPX3& batch, double super_resolution,
+    const std::vector<double>& tof_bin_edges, const std::string& mode);
 }  // namespace sophiread

--- a/sophiread/SophireadCLI/src/sophiread.cpp
+++ b/sophiread/SophireadCLI/src/sophiread.cpp
@@ -42,6 +42,11 @@ struct ProgramOptions {
   bool verbose = false;
 };
 
+/**
+ * @brief Print usage information.
+ *
+ * @param[in] program_name
+ */
 void print_usage(const char* program_name) {
   spdlog::info(
       "Usage: {} -i <input_tpx3> -H <output_hits> -E <output_events> [-u "
@@ -68,6 +73,12 @@ void print_usage(const char* program_name) {
   spdlog::info("  -v                       Enable verbose logging");
 }
 
+/**
+ * @brief Parse command line arguments.
+ *
+ * @param[in] argc
+ * @param[in] argv
+ */
 ProgramOptions parse_arguments(int argc, char* argv[]) {
   ProgramOptions options;
   int opt;

--- a/sophiread/SophireadCLI/src/sophiread.cpp
+++ b/sophiread/SophireadCLI/src/sophiread.cpp
@@ -9,6 +9,7 @@
  * @copyright Copyright (c) 2024
  * SPDX - License - Identifier: GPL - 3.0 +
  */
+#include <H5Epublic.h>
 #include <spdlog/spdlog.h>
 #include <tbb/tbb.h>
 #include <tiffio.h>
@@ -134,6 +135,10 @@ ProgramOptions parse_arguments(int argc, char* argv[]) {
  */
 int main(int argc, char* argv[]) {
   try {
+    // Turn off HDF5 error printing
+    // NOTE: we handle the errors ourselves
+    H5Eset_auto(H5E_DEFAULT, NULL, NULL);
+
     ProgramOptions options = parse_arguments(argc, argv);
 
     // Set logging level based on debug and verbose flags

--- a/sophiread/SophireadCLI/src/sophiread_core.cpp
+++ b/sophiread/SophireadCLI/src/sophiread_core.cpp
@@ -121,18 +121,6 @@ void timedProcessing(std::vector<TPX3> &batches, const std::vector<char> &chunk,
   spdlog::info("Process all hits -> neutrons: {} s", elapsed / 1e6);
 }
 
-std::vector<std::vector<std::vector<unsigned int>>> initializeTOFImages(
-    double super_resolution, const std::vector<double> &tof_bin_edges) {
-  int dim_x = static_cast<int>(517 * super_resolution);
-  int dim_y = static_cast<int>(517 * super_resolution);
-  std::vector<std::vector<std::vector<unsigned int>>> tof_images(
-      tof_bin_edges.size() - 1);
-  for (auto &tof_image : tof_images) {
-    tof_image.resize(dim_y, std::vector<unsigned int>(dim_x, 0));
-  }
-  return tof_images;
-}
-
 /**
  * @brief Timed save hits to HDF5.
  *
@@ -179,6 +167,18 @@ void timedSaveEventsToHDF5(const std::string &out_events,
       std::chrono::duration_cast<std::chrono::microseconds>(end - start)
           .count();
   spdlog::info("Save events to HDF5: {} s", elapsed / 1e6);
+}
+
+std::vector<std::vector<std::vector<unsigned int>>> initializeTOFImages(
+    double super_resolution, const std::vector<double> &tof_bin_edges) {
+  int dim_x = static_cast<int>(517 * super_resolution);
+  int dim_y = static_cast<int>(517 * super_resolution);
+  std::vector<std::vector<std::vector<unsigned int>>> tof_images(
+      tof_bin_edges.size() - 1);
+  for (auto &tof_image : tof_images) {
+    tof_image.resize(dim_y, std::vector<unsigned int>(dim_x, 0));
+  }
+  return tof_images;
 }
 
 void updateTOFImages(

--- a/sophiread/SophireadCLI/src/venus_auto_reducer.cpp
+++ b/sophiread/SophireadCLI/src/venus_auto_reducer.cpp
@@ -126,6 +126,10 @@ void process_existing_files(const std::string& input_dir,
                             std::unordered_set<std::string>& processed_files) {
   spdlog::info("Processing existing files in {}", input_dir);
 
+  unsigned long tdc_timestamp = 0;
+  unsigned long long gdc_timestamp = 0;
+  unsigned long timer_lsb32 = 0;
+
   // NOTE: we need to process files sequentially as we are accumulating the
   // counts to the
   //       same set of tiff files in the output folder
@@ -149,7 +153,8 @@ void process_existing_files(const std::string& input_dir,
         auto batches = sophiread::timedFindTPX3H(raw_data);
 
         // Process the data
-        sophiread::timedLocateTimeStamp(batches, raw_data);
+        sophiread::timedLocateTimeStamp(batches, raw_data, tdc_timestamp,
+                                        gdc_timestamp, timer_lsb32);
         sophiread::timedProcessing(batches, raw_data, config);
 
         // Generate output file name


### PR DESCRIPTION
# Description of Pull Request

This PR introduces the following changes:

- The command line tool `Sophiread` now process an input tpx3 file chunk by chunk.
- The write to HDF5 is now appending, allow multiple chunks from the same tpx3 file accumulated in the same HDF5 archive.
- Track timing signals (TDC, GDC) for each chunk, useful for runtime diagnostics.

EWM item: [Defect 7012](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=7012)

> Known issue: the chunking is now done by size, not packet, so we are losing the packet that got split between the chunks. This will affect the total number of hits and neutrons slightly, and using the largest chunk size allowed by the system ram can help reduce its negative impact.

## Purpose of work
<!--
Why has this work been done?
If there is no linked issue please provide appropriate context for this work.
-->
The raw tpx3 file collected with VENUS tpx3 detector is a lot larger than those from HFIR, and the system is not capable of store all bytes in its ram for processing, hence the chunked processing is necessary.

<!-- If the original issue was raised by a user they should be named here.
NOTE: you can use @GITHUB_USERNAME to reference a user.
-->

## Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

N/A

## Additional detail of work
<!-- [Optional] If there is additional detail that is relevant to this PR, please provide it here.
-->

N/A

## Testing instructions

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

- Build the feature branch within the conda dev environment.
- Run unit tests with `ctest -V --output-on-failure`
- Run the test to process with default chunk size (5G), i.e. `./Sophiread -i data/HV2700_1500_500_THLrel_274_sophy_chopper_60Hz_4.1mm_aperture_siemen_star_120s_000000.tpx3 -v`

<img width="816" alt="image" src="https://github.com/user-attachments/assets/eec784d6-f31c-44ed-8b47-eb8708795c6e">

- Run the test to process with 10 MB chunk size, i.e. `./Sophiread -i data/HV2700_1500_500_THLrel_274_sophy_chopper_60Hz_4.1mm_aperture_siemen_star_120s_000000.tpx3 -H hits.h5 -E neutrons.h5 -c 10 -v`

<img width="810" alt="image" src="https://github.com/user-attachments/assets/2c0b68f7-ee21-43b2-b2fc-f7b097854865">

- Run the test to output tof images with `./Sophiread -i data/HV2700_1500_500_THLrel_274_sophy_chopper_60Hz_4.1mm_aperture_siemen_star_120s_000000.tpx3 -c 10 -T tiff_out -v`

<img width="813" alt="image" src="https://github.com/user-attachments/assets/4ca2d927-2fd2-4fb0-ba18-3b0ba943afea">



<!-- and fix #xxxx or close #xxxx xor resolves #xxxx
NOTE: skip this part if not applicable to your PR.
-->
