### PR TITLE
Standalone spectra out

### DIFF
--- a/sophiread/SophireadCLI/include/sophiread_core.h
+++ b/sophiread/SophireadCLI/include/sophiread_core.h
@@ -46,4 +46,9 @@ void updateTOFImages(
     std::vector<std::vector<std::vector<unsigned int>>>& tof_images,
     const TPX3& batch, double super_resolution,
     const std::vector<double>& tof_bin_edges, const std::string& mode);
+std::vector<uint64_t> calculateSpectralCounts(
+    const std::vector<std::vector<std::vector<unsigned int>>>& tof_images);
+void writeSpectralFile(const std::string& filename,
+                       const std::vector<uint64_t>& spectral_counts,
+                       const std::vector<double>& tof_bin_edges);
 }  // namespace sophiread


### PR DESCRIPTION
# Description of Pull Request

The instrument scientist would like to have the capability of output a single spectra file for a given tpx3 raw data file without generating any tiff or hdf5 archives.
This PR allows the users to specify the standalone spectra file path, which is saved independent from tiff files.

## Purpose of work
<!--
Why has this work been done?
If there is no linked issue please provide appropriate context for this work.
-->
As described above.

<!-- If the original issue was raised by a user they should be named here.
NOTE: you can use @GITHUB_USERNAME to reference a user.
-->

## Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
N/A

## Additional detail of work
<!-- [Optional] If there is additional detail that is relevant to this PR, please provide it here.
-->
EWM item: [7119](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=7119)

## Testing instructions

- build the branch as usual and run unit test with `ctest -V` to make sure all unit test passes on the local system.
- run the two commands in the screenshot

<img width="1191" alt="image" src="https://github.com/user-attachments/assets/81738ae2-e880-4430-adda-7c24db67d8e1">


<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- and fix #xxxx or close #xxxx xor resolves #xxxx
NOTE: skip this part if not applicable to your PR.
-->
