### PR TITLE
Add new command line app to export GDC from raw tpx3 data to csv table

### DIFF
--- a/sophiread/CMakeLists.txt
+++ b/sophiread/CMakeLists.txt
@@ -40,6 +40,13 @@ find_package(TIFF REQUIRED)
 find_package(spdlog 1.8.0 REQUIRED)
 find_package(fmt 7.0.0 REQUIRED)
 
+# Set SPDLOG level
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+  add_definitions(-DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO)
+else()
+  add_definitions(-DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_DEBUG)
+endif()
+
 # Testing setup
 enable_testing()
 include(GoogleTest)

--- a/sophiread/FastSophiread/CMakeLists.txt
+++ b/sophiread/FastSophiread/CMakeLists.txt
@@ -1,6 +1,12 @@
 # Config FastSophireadLib
-set(SRC_FAST_FILES src/abs.cpp src/centroid.cpp src/disk_io.cpp
-                   src/fastgaussian.cpp src/hit.cpp src/tpx3_fast.cpp)
+set(SRC_FAST_FILES
+    src/abs.cpp
+    src/centroid.cpp
+    src/disk_io.cpp
+    src/fastgaussian.cpp
+    src/hit.cpp
+    src/tpx3_fast.cpp
+    src/gdc_processor.cpp)
 
 # ------------- SophireadLibFast -------------- #
 add_library(FastSophiread ${SRC_FAST_FILES})
@@ -46,6 +52,7 @@ add_sophiread_test(tpx3 ${HDF5_LIBRARIES})
 add_sophiread_test(abs)
 add_sophiread_test(centroid)
 add_sophiread_test(fastgaussian)
+add_sophiread_test(gdc_processor)
 
 # ------------------ Benchmarks ------------------ # Define a function to add
 # benchmark targets

--- a/sophiread/FastSophiread/include/gdc_processor.h
+++ b/sophiread/FastSophiread/include/gdc_processor.h
@@ -1,0 +1,40 @@
+/**
+ * @file gdc_processor.h
+ * @author Chen Zhang (zhangc@ornl.gov)
+ * @brief This file is for evaluating the GDC outside of standard data reduction
+ * flow.
+ * @version 0.1
+ * @date 2025-02-18
+ *
+ * @copyright Copyright (c) 2025
+ *
+ */
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+#include "tpx3_fast.h"  // we will reuse the tested GDC extractor from TPX3Fast
+
+struct GDCRecord {
+  int chip_id;
+  uint64_t gdc_value;
+  size_t file_offset;
+
+  GDCRecord(int id, uint64_t value, size_t offset)
+      : chip_id(id), gdc_value(value), file_offset(offset) {}
+};
+
+class GDCProcessor {
+ public:
+  GDCProcessor() = default;
+  ~GDCProcessor() = default;
+
+  std::vector<GDCRecord> processChunk(const char* data, size_t size,
+                                      size_t base_offset);
+
+ private:
+  static constexpr size_t PACKET_SIZE = 8;
+  unsigned long timer_lsb32 = 0;
+  unsigned long long gdc_timestamp = 0;
+};

--- a/sophiread/FastSophiread/src/gdc_processor.cpp
+++ b/sophiread/FastSophiread/src/gdc_processor.cpp
@@ -1,0 +1,82 @@
+/**
+ * @file gdc_processor.cpp
+ * @author Chen Zhang (zhangc@ornl.gov)
+ * @brief Extract GDC values from TPX3 raw data
+ * @version 0.1
+ * @date 2025-02-18
+ *
+ * @copyright Copyright (c) 2025
+ *
+ */
+#include "gdc_processor.h"
+
+#include <iostream>
+
+#include "spdlog/spdlog.h"
+
+std::vector<GDCRecord> GDCProcessor::processChunk(const char* data, size_t size,
+                                                  size_t base_offset) {
+  std::vector<GDCRecord> records;
+  records.reserve(size / PACKET_SIZE);
+
+  int current_chip_id = -1;
+  size_t offset = 0;
+
+  std::cout << "Processing chunk of size: " << size << std::endl;
+
+  while (offset + PACKET_SIZE <= size) {
+    const char* char_array = data + offset;
+
+    // Debug print each packet
+    std::cout << "Packet at offset " << offset << ": ";
+    for (int i = 0; i < 8; i++) {
+      std::cout << std::hex << (int)(unsigned char)char_array[i] << " ";
+    }
+    std::cout << std::endl;
+
+    // Check for TPX3 header
+    if (char_array[0] == 'T' && char_array[1] == 'P' && char_array[2] == 'X' &&
+        char_array[3] == '3') {
+      current_chip_id = static_cast<int>(char_array[4]);
+      std::cout << "Found TPX3 header for chip_id: " << current_chip_id
+                << std::endl;
+      offset += PACKET_SIZE;
+      // reset timer_lsb32 and gdc_timestamp to avoid using the values from
+      // previous chip timer_lsb32 = 0; gdc_timestamp = 0;
+      continue;
+    }
+
+    // Check for GDC packet
+    if ((char_array[7] & 0xF0) == 0x40) {
+      std::cout << "Found GDC packet, current_chip_id: " << current_chip_id
+                << std::endl;
+
+      // Debug print the unpacked GDC values
+      unsigned long* gdclast = (unsigned long*)(&char_array[0]);
+      unsigned long long mygdc = (((*gdclast) >> 16) & 0xFFFFFFFFFFFF);
+      bool is_gdc = ((mygdc >> 40) & 0xF) == 0x5;
+
+      std::cout << "gdclast: " << std::hex << *gdclast << std::endl;
+      std::cout << "mygdc: " << std::hex << mygdc << std::endl;
+      std::cout << "type: " << ((mygdc >> 40) & 0xF) << std::endl;
+
+      // Use our persisted state variables
+      update_gdc_timestamp_and_timer_lsb32(char_array, timer_lsb32,
+                                           gdc_timestamp);
+
+      std::cout << "After update: timer_lsb32=" << timer_lsb32
+                << " gdc_timestamp=" << gdc_timestamp << std::endl;
+
+      if (is_gdc && gdc_timestamp != 0 && current_chip_id >= 0) {
+        records.emplace_back(current_chip_id, gdc_timestamp,
+                             base_offset + offset);
+        std::cout << "Added record for chip " << current_chip_id << std::endl;
+      }
+    }
+
+    offset += PACKET_SIZE;
+  }
+
+  std::cout << "Returning " << records.size() << " records" << std::endl;
+  return records;
+}

--- a/sophiread/FastSophiread/src/gdc_processor.cpp
+++ b/sophiread/FastSophiread/src/gdc_processor.cpp
@@ -22,24 +22,24 @@ std::vector<GDCRecord> GDCProcessor::processChunk(const char* data, size_t size,
   int current_chip_id = -1;
   size_t offset = 0;
 
-  std::cout << "Processing chunk of size: " << size << std::endl;
+  SPDLOG_DEBUG("Processing chunk of size: {}", size);
 
   while (offset + PACKET_SIZE <= size) {
     const char* char_array = data + offset;
 
     // Debug print each packet
-    std::cout << "Packet at offset " << offset << ": ";
-    for (int i = 0; i < 8; i++) {
-      std::cout << std::hex << (int)(unsigned char)char_array[i] << " ";
-    }
-    std::cout << std::endl;
+    SPDLOG_DEBUG(
+        "Packet at offset {}: {:02x} {:02x} {:02x} {:02x} {:02x} {:02x} {:02x} "
+        "{:02x}",
+        offset, char_array[0], char_array[1], char_array[2], char_array[3],
+        char_array[4], char_array[5], char_array[6], char_array[7]);
 
     // Check for TPX3 header
     if (char_array[0] == 'T' && char_array[1] == 'P' && char_array[2] == 'X' &&
         char_array[3] == '3') {
       current_chip_id = static_cast<int>(char_array[4]);
-      std::cout << "Found TPX3 header for chip_id: " << current_chip_id
-                << std::endl;
+      SPDLOG_DEBUG("Found TPX3 header for chip_id: {}", current_chip_id);
+
       offset += PACKET_SIZE;
       // reset timer_lsb32 and gdc_timestamp to avoid using the values from
       // previous chip timer_lsb32 = 0; gdc_timestamp = 0;
@@ -48,35 +48,33 @@ std::vector<GDCRecord> GDCProcessor::processChunk(const char* data, size_t size,
 
     // Check for GDC packet
     if ((char_array[7] & 0xF0) == 0x40) {
-      std::cout << "Found GDC packet, current_chip_id: " << current_chip_id
-                << std::endl;
-
+      SPDLOG_DEBUG("Found GDC packet, current_chip_id: {}", current_chip_id);
       // Debug print the unpacked GDC values
       unsigned long* gdclast = (unsigned long*)(&char_array[0]);
       unsigned long long mygdc = (((*gdclast) >> 16) & 0xFFFFFFFFFFFF);
       bool is_gdc = ((mygdc >> 40) & 0xF) == 0x5;
 
-      std::cout << "gdclast: " << std::hex << *gdclast << std::endl;
-      std::cout << "mygdc: " << std::hex << mygdc << std::endl;
-      std::cout << "type: " << ((mygdc >> 40) & 0xF) << std::endl;
+      SPDLOG_DEBUG("gdclast: {:x}", *gdclast);
+      SPDLOG_DEBUG("mygdc: {:x}", mygdc);
+      SPDLOG_DEBUG("type: {}", ((mygdc >> 40) & 0xF));
 
       // Use our persisted state variables
       update_gdc_timestamp_and_timer_lsb32(char_array, timer_lsb32,
                                            gdc_timestamp);
 
-      std::cout << "After update: timer_lsb32=" << timer_lsb32
-                << " gdc_timestamp=" << gdc_timestamp << std::endl;
+      SPDLOG_DEBUG("After update: timer_lsb32={} gdc_timestamp={}", timer_lsb32,
+                   gdc_timestamp);
 
       if (is_gdc && gdc_timestamp != 0 && current_chip_id >= 0) {
         records.emplace_back(current_chip_id, gdc_timestamp,
                              base_offset + offset);
-        std::cout << "Added record for chip " << current_chip_id << std::endl;
+        SPDLOG_DEBUG("Added record for chip {}", current_chip_id);
       }
     }
 
     offset += PACKET_SIZE;
   }
 
-  std::cout << "Returning " << records.size() << " records" << std::endl;
+  SPDLOG_DEBUG("Returning {} records", records.size());
   return records;
 }

--- a/sophiread/FastSophiread/tests/test_gdc_processor.cpp
+++ b/sophiread/FastSophiread/tests/test_gdc_processor.cpp
@@ -1,0 +1,75 @@
+/**
+ * @file test_gdc_processor.cpp
+ * @brief Unit tests for GDCProcessor class
+ */
+#include <gtest/gtest.h>
+
+#include <iostream>
+
+#include "gdc_processor.h"
+
+TEST(GDCProcessorTest, TwoChipsSequence) {
+  std::vector<char> data(48);
+  char* ptr = data.data();
+
+  // Define integer values
+  const int timer_lsb32 = 1987;  // 0x07C3
+  const int gdc_msb16 = 0x1234;  // Correct MSB16 placement
+  const unsigned long long gdc_value =
+      (static_cast<unsigned long long>(gdc_msb16) << 32) | timer_lsb32;
+
+  // Construct correct packet values based on the detector reference
+  uint64_t lsb32_val = (0x4ULL << 60) | (0x4ULL << 56) | (0x00ULL << 48) |
+                       (static_cast<uint64_t>(timer_lsb32) << 16) | 0xAAAA;
+
+  uint64_t gdc_val = (0x4ULL << 60) | (0x5ULL << 56) | (0x00ULL << 32) |
+                     (static_cast<uint64_t>(gdc_msb16) << 16) | 0xAAAA;
+
+  // Chip 1 header
+  memcpy(ptr, "TPX3", 4);
+  ptr[4] = 1;
+  ptr[6] = 16;
+  ptr[7] = 0;
+  ptr += 8;
+
+  // Chip 1 LSB32 packet
+  memcpy(ptr, &lsb32_val, 8);
+  ptr += 8;
+
+  // Chip 1 GDC packet
+  memcpy(ptr, &gdc_val, 8);
+  ptr += 8;
+
+  // Chip 2 header
+  memcpy(ptr, "TPX3", 4);
+  ptr[4] = 2;
+  ptr[6] = 16;
+  ptr[7] = 0;
+  ptr += 8;
+
+  // Chip 2 LSB32 packet
+  memcpy(ptr, &lsb32_val, 8);
+  ptr += 8;
+
+  // Chip 2 GDC packet
+  memcpy(ptr, &gdc_val, 8);
+
+  // Debug: Print raw bytes
+  std::cout << "Corrected Mock Data Bytes:" << std::endl;
+  for (size_t i = 0; i < data.size(); i += 8) {
+    std::cout << "Packet at offset " << i << ": ";
+    for (size_t j = 0; j < 8; ++j) {
+      printf("%02X ", static_cast<unsigned char>(data[i + j]));
+    }
+    std::cout << std::endl;
+  }
+
+  // Process data
+  GDCProcessor processor;
+  auto records = processor.processChunk(data.data(), data.size(), 0);
+
+  // Verify
+  ASSERT_EQ(records.size(), 2);
+  EXPECT_EQ(records[0].gdc_value, gdc_value);
+  EXPECT_EQ(records[1].gdc_value, gdc_value);
+}

--- a/sophiread/FastSophiread/tests/test_gdc_processor.cpp
+++ b/sophiread/FastSophiread/tests/test_gdc_processor.cpp
@@ -2,15 +2,19 @@
  * @file test_gdc_processor.cpp
  * @brief Unit tests for GDCProcessor class
  */
+#include <fmt/format.h>
 #include <gtest/gtest.h>
 
 #include <iostream>
 
 #include "gdc_processor.h"
+#include "spdlog/spdlog.h"
 
 TEST(GDCProcessorTest, TwoChipsSequence) {
   std::vector<char> data(48);
   char* ptr = data.data();
+
+  spdlog::set_level(spdlog::level::debug);
 
   // Define integer values
   const int timer_lsb32 = 1987;  // 0x07C3
@@ -55,13 +59,19 @@ TEST(GDCProcessorTest, TwoChipsSequence) {
   memcpy(ptr, &gdc_val, 8);
 
   // Debug: Print raw bytes
-  std::cout << "Corrected Mock Data Bytes:" << std::endl;
+  SPDLOG_DEBUG("Corrected Mock Data Bytes:");
   for (size_t i = 0; i < data.size(); i += 8) {
-    std::cout << "Packet at offset " << i << ": ";
-    for (size_t j = 0; j < 8; ++j) {
-      printf("%02X ", static_cast<unsigned char>(data[i + j]));
-    }
-    std::cout << std::endl;
+    SPDLOG_DEBUG(
+        "Packet at offset {}: {}", i,
+        fmt::format("{:02X} {:02X} {:02X} {:02X} {:02X} {:02X} {:02X} {:02X}",
+                    static_cast<unsigned char>(data[i + 0]),
+                    static_cast<unsigned char>(data[i + 1]),
+                    static_cast<unsigned char>(data[i + 2]),
+                    static_cast<unsigned char>(data[i + 3]),
+                    static_cast<unsigned char>(data[i + 4]),
+                    static_cast<unsigned char>(data[i + 5]),
+                    static_cast<unsigned char>(data[i + 6]),
+                    static_cast<unsigned char>(data[i + 7])));
   }
 
   // Process data

--- a/sophiread/SophireadCLI/CMakeLists.txt
+++ b/sophiread/SophireadCLI/CMakeLists.txt
@@ -30,6 +30,13 @@ target_link_libraries(
           ${HDF5_LIBRARIES}
           ${TIFF_LIBRARIES})
 
+# ----------------- GDC EXTRACTOR APP ----------------- #
+add_executable(SophireadGDCExtractor src/main_gdc_extractor.cpp
+                                     src/gdc_extractor.cpp)
+target_link_libraries(
+  SophireadGDCExtractor PRIVATE FastSophiread pthread TBB::tbb spdlog::spdlog
+                                ${HDF5_LIBRARIES})
+
 # ----------------- TESTS ----------------- # UserConfig tests
 add_executable(UserConfigTest tests/test_user_config.cpp src/user_config.cpp)
 target_link_libraries(UserConfigTest PRIVATE FastSophiread spdlog::spdlog
@@ -74,6 +81,13 @@ add_custom_command(
     ${CMAKE_COMMAND} -E create_symlink
     ${PROJECT_BINARY_DIR}/SophireadCLI/venus_auto_reducer
     ${PROJECT_BINARY_DIR}/venus_auto_reducer)
+add_custom_command(
+  TARGET SophireadGDCExtractor
+  POST_BUILD
+  COMMAND
+    ${CMAKE_COMMAND} -E create_symlink
+    ${PROJECT_BINARY_DIR}/SophireadCLI/SophireadGDCExtractor
+    ${PROJECT_BINARY_DIR}/SophireadGDCExtractor)
 
 # ----------------- INSTALL ----------------- #
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
@@ -91,6 +105,10 @@ install(
 # Install the headers
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+# Install GDC Extractor
+install(TARGETS SophireadGDCExtractor
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # Set up packaging (optional)
 set(CPACK_RESOURCE_FILE_LICENSE "${PROJECT_SOURCE_DIR}/LICENSE")

--- a/sophiread/SophireadCLI/CMakeLists.txt
+++ b/sophiread/SophireadCLI/CMakeLists.txt
@@ -64,6 +64,13 @@ target_link_libraries(
           ${TIFF_LIBRARIES}
           TBB::tbb)
 gtest_discover_tests(SophireadCoreTest)
+# GDC extractor test
+add_executable(GDCExtractorTest tests/test_gdc_extractor.cpp
+                                src/gdc_extractor.cpp)
+target_link_libraries(
+  GDCExtractorTest PRIVATE FastSophiread spdlog::spdlog GTest::GTest
+                           GTest::Main ${HDF5_LIBRARIES})
+gtest_discover_tests(GDCExtractorTest)
 
 # ----------------- SYMLINK ----------------- # symlink the executable to the
 # build directory

--- a/sophiread/SophireadCLI/include/gdc_extractor.h
+++ b/sophiread/SophireadCLI/include/gdc_extractor.h
@@ -23,6 +23,12 @@ struct GDCExtractorOptions {
   size_t chunk_size = 5ULL * 1024 * 1024 * 1024;  // Default 5GB
   bool debug_logging = false;
   bool verbose = false;
+
+  // Validation constants
+  static constexpr size_t MIN_CHUNK_SIZE = 1ULL * 1024 * 1024;          // 1MB
+  static constexpr size_t MAX_CHUNK_SIZE = 20ULL * 1024 * 1024 * 1024;  // 20GB
+
+  bool validate() const;
 };
 
 class GDCExtractor {

--- a/sophiread/SophireadCLI/include/gdc_extractor.h
+++ b/sophiread/SophireadCLI/include/gdc_extractor.h
@@ -1,0 +1,43 @@
+/**
+ * @file gdc_extractor.h
+ * @author Chen Zhang (zhangc@ornl.gov)
+ * @brief Command line tool for extracting GDC information from TPX3 files
+ * @version 0.1
+ * @date 2025-02-19
+ *
+ * @copyright Copyright (c) 2025
+ * SPDX - License - Identifier: GPL - 3.0 +
+ */
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "gdc_processor.h"
+
+namespace sophiread {
+
+struct GDCExtractorOptions {
+  std::string input_tpx3;
+  std::string output_csv;
+  size_t chunk_size = 5ULL * 1024 * 1024 * 1024;  // Default 5GB
+  bool debug_logging = false;
+  bool verbose = false;
+};
+
+class GDCExtractor {
+ public:
+  explicit GDCExtractor(const GDCExtractorOptions& options);
+
+  bool process();
+
+ private:
+  GDCExtractorOptions options_;
+  GDCProcessor processor_;
+
+  bool writeCSVHeader(std::ofstream& file) const;
+  bool writeRecords(std::ofstream& file,
+                    const std::vector<GDCRecord>& records) const;
+};
+
+}  // namespace sophiread

--- a/sophiread/SophireadCLI/src/gdc_extractor.cpp
+++ b/sophiread/SophireadCLI/src/gdc_extractor.cpp
@@ -18,6 +18,54 @@
 
 namespace sophiread {
 
+bool GDCExtractorOptions::validate() const {
+  // Check input file existence
+  if (!std::filesystem::exists(input_tpx3)) {
+    spdlog::error("Input file does not exist: {}", input_tpx3);
+    return false;
+  }
+
+  // Check input file is readable
+  std::ifstream test_input(input_tpx3);
+  if (!test_input.good()) {
+    spdlog::error("Input file is not readable: {}", input_tpx3);
+    return false;
+  }
+  test_input.close();
+
+  // Check output directory exists or can be created
+  std::filesystem::path output_path =
+      std::filesystem::path(output_csv).parent_path();
+  if (!output_path.empty()) {
+    std::error_code ec;
+    if (!std::filesystem::exists(output_path)) {
+      if (!std::filesystem::create_directories(output_path, ec)) {
+        spdlog::error("Failed to create output directory: {}",
+                      output_path.string());
+        return false;
+      }
+    }
+  }
+
+  // Test if output file is writable
+  std::ofstream test_output(output_csv, std::ios::app);
+  if (!test_output.good()) {
+    spdlog::error("Output file is not writable: {}", output_csv);
+    return false;
+  }
+  test_output.close();
+
+  // Validate chunk size
+  if (chunk_size < MIN_CHUNK_SIZE || chunk_size > MAX_CHUNK_SIZE) {
+    spdlog::error("Invalid chunk size: {}. Must be between {} MB and {} GB",
+                  chunk_size / (1024 * 1024), MIN_CHUNK_SIZE / (1024 * 1024),
+                  MAX_CHUNK_SIZE / (1024 * 1024 * 1024));
+    return false;
+  }
+
+  return true;
+}
+
 GDCExtractor::GDCExtractor(const GDCExtractorOptions& options)
     : options_(options) {}
 

--- a/sophiread/SophireadCLI/src/gdc_extractor.cpp
+++ b/sophiread/SophireadCLI/src/gdc_extractor.cpp
@@ -1,0 +1,93 @@
+/**
+ * @file gdc_extractor.cpp
+ * @author Chen Zhang (zhangc@ornl.gov)
+ * @brief Implementation of GDC extraction functionality
+ * @version 0.1
+ * @date 2025-02-19
+ *
+ * @copyright Copyright (c) 2025
+ * SPDX - License - Identifier: GPL - 3.0 +
+ */
+#include "gdc_extractor.h"
+
+#include <spdlog/spdlog.h>
+
+#include <fstream>
+
+#include "disk_io.h"
+
+namespace sophiread {
+
+GDCExtractor::GDCExtractor(const GDCExtractorOptions& options)
+    : options_(options) {}
+
+bool GDCExtractor::writeCSVHeader(std::ofstream& file) const {
+  try {
+    file << "chip_id,gdc_value,file_offset,timestamp_ns\n";
+    return true;
+  } catch (const std::exception& e) {
+    spdlog::error("Failed to write CSV header: {}", e.what());
+    return false;
+  }
+}
+
+bool GDCExtractor::writeRecords(std::ofstream& file,
+                                const std::vector<GDCRecord>& records) const {
+  try {
+    for (const auto& record : records) {
+      file << record.chip_id << "," << record.gdc_value << ","
+           << record.file_offset << "," << (record.gdc_value * 25)
+           << "\n";  // Convert to nanoseconds
+    }
+    return true;
+  } catch (const std::exception& e) {
+    spdlog::error("Failed to write records: {}", e.what());
+    return false;
+  }
+}
+
+bool GDCExtractor::process() {
+  spdlog::info("Processing file: {}", options_.input_tpx3);
+
+  // Open output CSV file
+  std::ofstream csv_file(options_.output_csv);
+  if (!csv_file.is_open()) {
+    spdlog::error("Failed to open output file: {}", options_.output_csv);
+    return false;
+  }
+
+  // Write CSV header
+  if (!writeCSVHeader(csv_file)) {
+    return false;
+  }
+
+  // Setup file reader
+  TPX3FileReader file_reader(options_.input_tpx3);
+  const size_t total_size = file_reader.getTotalSize();
+  size_t processed_size = 0;
+
+  // Process chunks
+  while (!file_reader.isEOF()) {
+    auto chunk = file_reader.readChunk(options_.chunk_size);
+    if (chunk.empty()) break;
+
+    // Process chunk
+    auto records =
+        processor_.processChunk(chunk.data(), chunk.size(), processed_size);
+
+    // Write records
+    if (!writeRecords(csv_file, records)) {
+      return false;
+    }
+
+    // Update progress
+    processed_size += chunk.size();
+    float progress = static_cast<float>(processed_size) / total_size * 100.0f;
+    spdlog::info("Progress: {:.2f}%", progress);
+  }
+
+  spdlog::info("GDC extraction completed successfully");
+  return true;
+}
+
+}  // namespace sophiread

--- a/sophiread/SophireadCLI/src/gdc_extractor.cpp
+++ b/sophiread/SophireadCLI/src/gdc_extractor.cpp
@@ -12,15 +12,17 @@
 
 #include <spdlog/spdlog.h>
 
+#include <filesystem>
 #include <fstream>
 
 #include "disk_io.h"
 
+namespace fs = std::filesystem;
 namespace sophiread {
 
 bool GDCExtractorOptions::validate() const {
   // Check input file existence
-  if (!std::filesystem::exists(input_tpx3)) {
+  if (!fs::exists(input_tpx3)) {
     spdlog::error("Input file does not exist: {}", input_tpx3);
     return false;
   }

--- a/sophiread/SophireadCLI/src/main_gdc_extractor.cpp
+++ b/sophiread/SophireadCLI/src/main_gdc_extractor.cpp
@@ -1,0 +1,88 @@
+/**
+ * @file main_gdc_extractor.cpp
+ * @author Chen Zhang (zhangc@ornl.gov)
+ * @brief Main entry point for GDC extraction tool
+ * @version 0.1
+ * @date 2025-02-19
+ *
+ * @copyright Copyright (c) 2025
+ * SPDX - License - Identifier: GPL - 3.0 +
+ */
+#include <spdlog/spdlog.h>
+#include <unistd.h>
+
+#include "gdc_extractor.h"
+
+void print_usage(const char* program_name) {
+  spdlog::info(
+      "Usage: {} -i <input_tpx3> -o <output_csv> [-c <chunk_size>] [-d] [-v]",
+      program_name);
+  spdlog::info("Options:");
+  spdlog::info("  -i <input_tpx3>    Input TPX3 file");
+  spdlog::info("  -o <output_csv>    Output CSV file");
+  spdlog::info("  -c <chunk_size>    Chunk size in MB (default: 5120)");
+  spdlog::info("  -d                 Enable debug logging");
+  spdlog::info("  -v                 Enable verbose logging");
+}
+
+sophiread::GDCExtractorOptions parse_arguments(int argc, char* argv[]) {
+  sophiread::GDCExtractorOptions options;
+  int opt;
+
+  while ((opt = getopt(argc, argv, "i:o:c:dv")) != -1) {
+    switch (opt) {
+      case 'i':
+        options.input_tpx3 = optarg;
+        break;
+      case 'o':
+        options.output_csv = optarg;
+        break;
+      case 'c':
+        options.chunk_size =
+            static_cast<size_t>(std::stoull(optarg)) * 1024 * 1024;
+        break;
+      case 'd':
+        options.debug_logging = true;
+        break;
+      case 'v':
+        options.verbose = true;
+        break;
+      default:
+        print_usage(argv[0]);
+        throw std::runtime_error("Invalid argument");
+    }
+  }
+
+  if (options.input_tpx3.empty() || options.output_csv.empty()) {
+    print_usage(argv[0]);
+    throw std::runtime_error("Missing required arguments");
+  }
+
+  return options;
+}
+
+int main(int argc, char* argv[]) {
+  try {
+    auto options = parse_arguments(argc, argv);
+
+    // Set logging level
+    if (options.debug_logging) {
+      spdlog::set_level(spdlog::level::debug);
+    } else if (options.verbose) {
+      spdlog::set_level(spdlog::level::info);
+    } else {
+      spdlog::set_level(spdlog::level::warn);
+    }
+
+    // Process file
+    sophiread::GDCExtractor extractor(options);
+    if (!extractor.process()) {
+      return 1;
+    }
+
+    return 0;
+  } catch (const std::exception& e) {
+    spdlog::error("Error: {}", e.what());
+    return 1;
+  }
+}

--- a/sophiread/SophireadCLI/tests/test_gdc_extractor.cpp
+++ b/sophiread/SophireadCLI/tests/test_gdc_extractor.cpp
@@ -1,0 +1,40 @@
+#include <gtest/gtest.h>
+
+#include "gdc_extractor.h"
+
+TEST(GDCExtractorOptionsTest, ChunkSizeValidation) {
+  // Test minimum chunk size validation
+  sophiread::GDCExtractorOptions min_opts;
+  min_opts.input_tpx3 = "/dev/null";
+  min_opts.output_csv = "test.csv";
+  min_opts.chunk_size = min_opts.MIN_CHUNK_SIZE - 1;  // Just below minimum
+  EXPECT_FALSE(min_opts.validate());
+
+  // Test maximum chunk size validation
+  sophiread::GDCExtractorOptions max_opts;
+  max_opts.input_tpx3 = "/dev/null";
+  max_opts.output_csv = "test.csv";
+  max_opts.chunk_size = max_opts.MAX_CHUNK_SIZE + 1;  // Just above maximum
+  EXPECT_FALSE(max_opts.validate());
+
+  // Test valid chunk size
+  sophiread::GDCExtractorOptions valid_opts;
+  valid_opts.input_tpx3 = "/dev/null";
+  valid_opts.output_csv = "test.csv";
+  valid_opts.chunk_size = 10ULL * 1024 * 1024;  // 10MB
+  EXPECT_TRUE(valid_opts.validate());
+}
+
+TEST(GDCExtractorOptionsTest, FileAccessValidation) {
+  sophiread::GDCExtractorOptions opts;
+  opts.chunk_size = 10ULL * 1024 * 1024;  // Valid chunk size
+
+  // Test non-existent input file
+  opts.input_tpx3 = "nonexistent.tpx3";
+  EXPECT_FALSE(opts.validate());
+
+  // Test non-writable output path
+  opts.input_tpx3 = "/dev/null";  // Exists and readable
+  opts.output_csv = "/nonexistent/path/output.csv";
+  EXPECT_FALSE(opts.validate());
+}


### PR DESCRIPTION
# Description of Pull Request

This PR introduces a new command line application that will extract GDC from raw tpx3 data into a csv table.

## Purpose of work

This work is in response to request in EWM item [9586](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=9586)

## Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
This pull request introduces the GDC extraction functionality to the `sophiread` project. The changes include adding a new GDC processor, integrating it into the build system, and creating associated tests.

### GDC Extraction Functionality:

* Added `GDCProcessor` class and `GDCRecord` struct to process GDC data packets. (`sophiread/FastSophiread/include/gdc_processor.h`, `sophiread/FastSophiread/src/gdc_processor.cpp`) [[1]](diffhunk://#diff-3ad4a6a03bae912ba10d2197e31c5c5f1fe092a13afdaa192b330fc009790e38R1-R40) [[2]](diffhunk://#diff-309ffebab2099b64cc1af8325c81c2a0c000ed97cb0172681f6b3d2090a4794aR1-R80)
* Created `GDCExtractor` class and `GDCExtractorOptions` struct for the command-line tool to extract GDC information from TPX3 files and save it to CSV. (`sophiread/SophireadCLI/include/gdc_extractor.h`, `sophiread/SophireadCLI/src/gdc_extractor.cpp`) [[1]](diffhunk://#diff-ef55e84dff08ebc5b5bc4b3fe5d89e7b9048f32557e088629cfa483b9664b082R1-R49) [[2]](diffhunk://#diff-2e44b95dfef60647e0ab907835a839d7ae46beece6856bd758d91b91bc09a9ddR1-R143)
* Implemented the main entry point for the GDC extraction tool. (`sophiread/SophireadCLI/src/main_gdc_extractor.cpp`)

### Build System Integration:

* Updated `CMakeLists.txt` files to include the new GDC processor and extractor components, and added executable targets for the GDC extractor and its tests. (`sophiread/FastSophiread/CMakeLists.txt`, `sophiread/SophireadCLI/CMakeLists.txt`) [[1]](diffhunk://#diff-7e3b94bf093d82a27f853f519217d2d71709b4dc62dcf67c2ea87d111f5c7e35L2-R9) [[2]](diffhunk://#diff-e6d28838ce4a7e128734fed95f782c926bcfe6242cff3778f586a760e9605fb2R33-R39) [[3]](diffhunk://#diff-e6d28838ce4a7e128734fed95f782c926bcfe6242cff3778f586a760e9605fb2R67-R73) [[4]](diffhunk://#diff-e6d28838ce4a7e128734fed95f782c926bcfe6242cff3778f586a760e9605fb2R91-R97) [[5]](diffhunk://#diff-e6d28838ce4a7e128734fed95f782c926bcfe6242cff3778f586a760e9605fb2R116-R119)

### Testing:

* Added unit tests for `GDCProcessor` and `GDCExtractor` classes to ensure correct functionality and validation. (`sophiread/FastSophiread/tests/test_gdc_processor.cpp`, `sophiread/SophireadCLI/tests/test_gdc_extractor.cpp`) [[1]](diffhunk://#diff-8d398ecbc05cb88c79d15fbea8c3214e5e985624d1638160946cab2cf058a2ceR1-R85) [[2]](diffhunk://#diff-cba3d33175db5547013c541e44e92c3857e2069e9fca2c7801598dea2e703e81R1-R40)

These changes collectively introduce the capability to process GDC data from TPX3 files and integrate the functionality into the existing `sophiread` project structure, along with comprehensive testing to ensure reliability.


## Testing instructions

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

- Clone the feature branch
- Setup conda environment using corresponding environment file. For linux, please use `environment_linux.yml`
- Activate the conda environment and use the following command to build

```bash
cd sophiread
mkdir build
cd build
cmake ..
make -j4
``` 

- Wait for the compilation complete, then use `ctest -V --output-on-failure` to run unit test, all unit tests should pass

- Use the following command to extract GDC values from example tpx3 data

```bash
./SophireadGDCExtractor -i data/HV2700_1500_500_THLrel_274_sophy_chopper_60Hz_4.1mm_aperture_siemen_star_120s_000000.tpx3 -o test.csv -v
```

The beginning of the csv will contain GDC information as the following table

| chip_id | gdc_value  | file_offset | timestamp_ns |
|---------|-----------|-------------|--------------|
| 0       | 289534610 | 9683376     | 7238365250   |
| 1       | 289706099 | 9747496     | 7242652475   |
| 2       | 289877600 | 9816104     | 7246940000   |
| 3       | 290049095 | 9981456     | 7251227375   |
| 0       | 330262702 | 34124664    | 8256567550   |
| 1       | 330434193 | 34218344    | 8260854825   |
| 2       | 330605693 | 34330976    | 8265142325   |
| 3       | 330777188 | 34389752    | 8269429700   |
| 0       | 369531652 | 57886832    | 9238291300   |

