### PR TITLE
ci: drop v0.41.4 pixi-version pin in unittest workflow

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -21,7 +21,6 @@ jobs:
       - uses: actions/checkout@v6
       - uses: prefix-dev/setup-pixi@v0.9.5
         with:
-          pixi-version: v0.41.4
           manifest-path: sophiread/pixi.toml
       - name: Build and test
         run: |
@@ -37,7 +36,6 @@ jobs:
       - uses: actions/checkout@v6
       - uses: prefix-dev/setup-pixi@v0.9.5
         with:
-          pixi-version: v0.41.4
           manifest-path: sophiread/pixi.toml
       - name: Build and test
         run: |


### PR DESCRIPTION
## Summary
- Removes the `pixi-version: v0.41.4` pin from `unittest.yml` (linux + macos jobs) so the workflow uses the default pixi installed by `prefix-dev/setup-pixi`.

## Why
Aligns this repo with the rest of the workspace — same pattern as the recent timepix_geometry_correction (#70) and RootPlantProcessing (#75) fixes. Prevents future lockfile-version drift.

## Test plan
- [ ] linux unittest passes on this PR
- [ ] macos unittest passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)