### PR TITLE
security: pin third-party GitHub Actions to commit SHAs + least-privilege permissions

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -11,6 +11,9 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: read
+
 jobs:
   ubuntu-latest:
     runs-on: ubuntu-latest
@@ -19,7 +22,7 @@ jobs:
         working-directory: sophiread
     steps:
       - uses: actions/checkout@v6
-      - uses: prefix-dev/setup-pixi@v0.9.6
+      - uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
         with:
           manifest-path: sophiread/pixi.toml
       - name: Build and test
@@ -34,7 +37,7 @@ jobs:
         working-directory: sophiread
     steps:
       - uses: actions/checkout@v6
-      - uses: prefix-dev/setup-pixi@v0.9.6
+      - uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
         with:
           manifest-path: sophiread/pixi.toml
       - name: Build and test


### PR DESCRIPTION
## What

Hardens the repo's GitHub Actions against supply-chain risk:

- **SHA-pin third-party actions.** Pinned every non-first-party action to a full 40-char commit SHA, retaining a trailing `# version` comment for readability/dependabot.
- **Least-privilege permissions.** Added a top-level `permissions: contents: read` block to the pure-CI workflow `unittest.yml` (it had no existing permissions block and uses no write-requiring features).

First-party `actions/*` (e.g. `actions/checkout@v6`) are intentionally left tag-pinned per group convention.

## Why

Supply-chain hardening per group convention (pin third-party GitHub Actions to SHA hashes where possible). From the 2026-06-22 workspace GitHub Actions security audit.

## Pins applied

- `prefix-dev/setup-pixi@v0.9.6` -> `prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6` (2 occurrences in `unittest.yml`)

No `dtolnay/rust-toolchain` or `taiki-e/install-action` usages are present in this repo's workflows, so those special-case notes do not apply here.

## Files changed

- `.github/workflows/unittest.yml`

No behavior change intended; CI on this PR validates.

🤖 Assisted with Claude Code
